### PR TITLE
feat(planning): cherry-pick PRs of planning_data_analyzer and perception_reproducer for DLR tests

### DIFF
--- a/bag2lanelet/scripts/bag2map.py
+++ b/bag2lanelet/scripts/bag2map.py
@@ -6,6 +6,7 @@ import pathlib
 
 from bag2way import bag2point_stamped
 import folium
+
 from tools.bag2lanelet.scripts.lanelet_xml import LaneletMap
 
 

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -35,6 +35,10 @@
       gt_trajectory_topic: "/planning/ground_truth_trajectory"
       gt_sync_tolerance_ms: 200.0
       metric_variant: ""
+      # DLR result horizon checkpoints in seconds.
+      # ADE/FDE are reported at these horizons plus "full" (entire trajectory).
+      # Trajectories shorter than a horizon are excluded from that horizon with 0.1s tolerance.
+      evaluation_horizons: [1.0, 2.0, 4.0, 8.0]
 
     # OR Scene Evaluation Configuration (only used when mode="or_scene")
     or_scene_evaluation:

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -34,6 +34,7 @@
       gt_source_mode: "kinematic_state"
       gt_trajectory_topic: "/planning/ground_truth_trajectory"
       gt_sync_tolerance_ms: 200.0
+      metric_variant: ""
 
     # OR Scene Evaluation Configuration (only used when mode="or_scene")
     or_scene_evaluation:

--- a/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
+++ b/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
@@ -2,6 +2,8 @@
   <arg name="bag_path" description="Path to rosbag file or directory"/>
   <arg name="config_file" default="$(find-pkg-share autoware_planning_data_analyzer)/config/planning_data_analyzer.param.yaml" description="Path to parameter file"/>
   <arg name="output_dir" description="Output directory for evaluation results (overrides config file if specified)"/>
+  <arg name="trajectory_topic" default="/planning/trajectory" description="Trajectory topic to evaluate"/>
+  <arg name="open_loop_metric_variant" default="" description="Variant label for open-loop metric topics"/>
   <arg name="gt_source_mode" default="kinematic_state" description="GT source mode: kinematic_state or gt_trajectory"/>
   <arg name="gt_trajectory_topic" default="/planning/ground_truth_trajectory" description="GT trajectory topic for gt_trajectory mode"/>
   <arg name="gt_sync_tolerance_ms" default="200.0" description="Sync tolerance (ms) for GT trajectory alignment"/>
@@ -10,6 +12,8 @@
     <param from="$(var config_file)"/>
     <param name="input_bag_path" value="$(var bag_path)"/>
     <param name="output_dir" value="$(var output_dir)"/>
+    <param name="trajectory_topic" value="$(var trajectory_topic)"/>
+    <param name="open_loop.metric_variant" value="$(var open_loop_metric_variant)"/>
     <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
     <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
     <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>

--- a/planning/autoware_planning_data_analyzer/package.xml
+++ b/planning/autoware_planning_data_analyzer/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="daniel.sanchez@tier4.jp">Daniel Sanchez</maintainer>
   <maintainer email="go.sakayori@tier4.jp">Go Sakayori</maintainer>
   <maintainer email="cheng.lin@tier4.jp">Dio Lin</maintainer>
+  <maintainer email="temkei.kem@tier4.jp">Temkei Kem</maintainer>
+  <maintainer email="beomseok.kim.2@tier4.jp">Beomseok Kim</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="go.sakayori@tier4.jp">Go Sakayori</author>

--- a/planning/autoware_planning_data_analyzer/package.xml
+++ b/planning/autoware_planning_data_analyzer/package.xml
@@ -4,11 +4,12 @@
   <name>autoware_planning_data_analyzer</name>
   <version>0.2.0</version>
   <description>The autoware_planning_data_analyzer package</description>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
+  <maintainer email="daniel.sanchez@tier4.jp">Daniel Sanchez</maintainer>
   <maintainer email="go.sakayori@tier4.jp">Go Sakayori</maintainer>
+  <maintainer email="cheng.lin@tier4.jp">Dio Lin</maintainer>
   <license>Apache License 2.0</license>
 
-  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
+  <author email="go.sakayori@tier4.jp">Go Sakayori</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -265,10 +265,10 @@ void AutowarePlanningDataAnalyzerNode::replace_input_bag_with_merged_evaluation(
 
   const std::filesystem::path input_bag_path(bag_path_);
   const std::filesystem::path temp_root = evaluation_metrics_bag_path_.parent_path();
-  const std::filesystem::path merged_bag_path =
-    temp_root / (input_bag_path.filename().string() + ".tmp");
-  const std::filesystem::path backup_bag_path =
-    temp_root / (input_bag_path.filename().string() + ".bak");
+  const std::filesystem::path merged_bag_parent = temp_root / "merged";
+  const std::filesystem::path backup_bag_parent = temp_root / "backup";
+  const std::filesystem::path merged_bag_path = merged_bag_parent / input_bag_path.filename();
+  const std::filesystem::path backup_bag_path = backup_bag_parent / input_bag_path.filename();
 
   const auto move_path =
     [](const std::filesystem::path & source, const std::filesystem::path & target) {
@@ -287,12 +287,14 @@ void AutowarePlanningDataAnalyzerNode::replace_input_bag_with_merged_evaluation(
       }
     };
 
-  if (std::filesystem::exists(merged_bag_path)) {
-    std::filesystem::remove_all(merged_bag_path);
+  if (std::filesystem::exists(merged_bag_parent)) {
+    std::filesystem::remove_all(merged_bag_parent);
   }
-  if (std::filesystem::exists(backup_bag_path)) {
-    std::filesystem::remove_all(backup_bag_path);
+  if (std::filesystem::exists(backup_bag_parent)) {
+    std::filesystem::remove_all(backup_bag_parent);
   }
+  std::filesystem::create_directories(merged_bag_parent);
+  std::filesystem::create_directories(backup_bag_parent);
 
   try {
     merge_bags({input_bag_path, evaluation_metrics_bag_path_}, merged_bag_path);
@@ -307,12 +309,18 @@ void AutowarePlanningDataAnalyzerNode::replace_input_bag_with_merged_evaluation(
 
     std::filesystem::remove_all(backup_bag_path);
     std::filesystem::remove_all(evaluation_metrics_bag_path_);
-  } catch (...) {
-    if (std::filesystem::exists(merged_bag_path)) {
-      std::filesystem::remove_all(merged_bag_path);
+    if (std::filesystem::exists(merged_bag_parent)) {
+      std::filesystem::remove_all(merged_bag_parent);
     }
-    if (std::filesystem::exists(backup_bag_path)) {
-      std::filesystem::remove_all(backup_bag_path);
+    if (std::filesystem::exists(backup_bag_parent)) {
+      std::filesystem::remove_all(backup_bag_parent);
+    }
+  } catch (...) {
+    if (std::filesystem::exists(merged_bag_parent)) {
+      std::filesystem::remove_all(merged_bag_parent);
+    }
+    if (std::filesystem::exists(backup_bag_parent)) {
+      std::filesystem::remove_all(backup_bag_parent);
     }
     if (std::filesystem::exists(evaluation_metrics_bag_path_)) {
       std::filesystem::remove_all(evaluation_metrics_bag_path_);

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -142,15 +142,16 @@ void AutowarePlanningDataAnalyzerNode::setup_evaluation_bag_writer()
 
     // Get output directory
     auto output_dir = get_or_declare_parameter<std::string>(*this, "output_dir");
-
-    // Expand home directory if needed
-    output_dir = utils::expand_home_directory(output_dir);
+    const std::filesystem::path output_dir_path(output_dir);
+    if (output_dir.empty() || !output_dir_path.is_absolute()) {
+      throw std::runtime_error("Parameter 'output_dir' must be an absolute path.");
+    }
 
     // Generate output bag path (use .mcap extension to save directly as single file)
-    const auto output_bag_path = (std::filesystem::path(output_dir) / "mcap").string();
+    const auto output_bag_path = (output_dir_path / "mcap").string();
 
     // Ensure output directory exists and is writable
-    utils::ensure_directory_writable(output_dir, get_logger());
+    utils::ensure_directory_writable(output_dir_path, get_logger());
 
     // Setup bag writer with MCAP format
     const rosbag2_storage::StorageOptions storage_options{output_bag_path, "mcap"};
@@ -254,6 +255,11 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   topic_names.steering_topic = steering_topic_name_;
   topic_names.evaluation_interval_ms = evaluation_interval_ms_;
   topic_names.sync_tolerance_ms = sync_tolerance_ms_;
+  auto output_dir = get_or_declare_parameter<std::string>(*this, "output_dir");
+  const std::filesystem::path output_dir_path(output_dir);
+  if (output_dir.empty() || !output_dir_path.is_absolute()) {
+    throw std::runtime_error("Parameter 'output_dir' must be an absolute path.");
+  }
 
   switch (evaluation_mode_) {
     case EvaluationMode::OPEN_LOOP: {
@@ -266,6 +272,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
           ". Expected 'kinematic_state' or 'gt_trajectory'.");
       }
       OpenLoopEvaluator evaluator(get_logger(), route_handler_, gt_mode, gt_sync_tolerance_ms_);
+      evaluator.set_json_output_dir(output_dir_path.string());
       auto times =
         evaluator.run_evaluation_from_bag(bag_path_, evaluation_bag_writer_.get(), topic_names);
       start_time = times.first;
@@ -298,6 +305,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       ORSceneEvaluator evaluator(
         get_logger(), route_handler_, time_window_sec, success_criteria, enable_debug_viz,
         debug_output_dir);
+      evaluator.set_json_output_dir(output_dir_path.string());
 
       // Set OR events JSON paths if provided
       const auto or_events_input_path =

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -47,6 +47,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <set>
@@ -61,6 +62,23 @@ namespace autoware::planning_data_analyzer
 using autoware_utils::create_marker_color;
 using autoware_utils_rclcpp::get_or_declare_parameter;
 
+namespace
+{
+
+std::filesystem::path resolve_bag_uri(const std::string & input_bag_path)
+{
+  const std::filesystem::path input_path(input_bag_path);
+  if (
+    std::filesystem::is_regular_file(input_path) &&
+    std::filesystem::exists(input_path.parent_path() / "metadata.yaml")) {
+    return input_path.parent_path();
+  }
+
+  return input_path;
+}
+
+}  // namespace
+
 AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   const rclcpp::NodeOptions & node_options)
 : Node("autoware_planning_data_analyzer", node_options),
@@ -69,7 +87,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   setup_evaluation_bag_writer();
 
   // Open bag file
-  bag_path_ = get_or_declare_parameter<std::string>(*this, "input_bag_path");
+  bag_path_ =
+    resolve_bag_uri(get_or_declare_parameter<std::string>(*this, "input_bag_path")).string();
   try {
     bag_reader_.open(bag_path_);
   } catch (const std::exception & e) {
@@ -125,14 +144,7 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
 
 AutowarePlanningDataAnalyzerNode::~AutowarePlanningDataAnalyzerNode()
 {
-  if (evaluation_bag_writer_) {
-    try {
-      evaluation_bag_writer_->close();
-      RCLCPP_INFO(get_logger(), "Evaluation bag writer closed successfully");
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(get_logger(), "Error closing evaluation bag writer: %s", e.what());
-    }
-  }
+  close_evaluation_bag_writer();
 }
 
 void AutowarePlanningDataAnalyzerNode::setup_evaluation_bag_writer()
@@ -147,14 +159,17 @@ void AutowarePlanningDataAnalyzerNode::setup_evaluation_bag_writer()
       throw std::runtime_error("Parameter 'output_dir' must be an absolute path.");
     }
 
-    // Generate output bag path (use .mcap extension to save directly as single file)
-    const auto output_bag_path = (output_dir_path / "mcap").string();
-
-    // Ensure output directory exists and is writable
     utils::ensure_directory_writable(output_dir_path, get_logger());
+    const auto temp_root = std::filesystem::temp_directory_path() / "planning_data_analyzer";
+    utils::ensure_directory_writable(temp_root, get_logger());
 
-    // Setup bag writer with MCAP format
-    const rosbag2_storage::StorageOptions storage_options{output_bag_path, "mcap"};
+    evaluation_metrics_bag_path_ = temp_root / "evaluation_metrics_tmp.mcap";
+    if (std::filesystem::exists(evaluation_metrics_bag_path_)) {
+      std::filesystem::remove_all(evaluation_metrics_bag_path_);
+    }
+
+    const rosbag2_storage::StorageOptions storage_options{
+      evaluation_metrics_bag_path_.string(), "mcap"};
     const rosbag2_cpp::ConverterOptions converter_options{
       rmw_get_serialization_format(), rmw_get_serialization_format()};
 
@@ -162,6 +177,147 @@ void AutowarePlanningDataAnalyzerNode::setup_evaluation_bag_writer()
   } catch (const std::exception & e) {
     RCLCPP_ERROR(get_logger(), "Failed to setup evaluation bag writer: %s", e.what());
     evaluation_bag_writer_ = nullptr;
+  }
+}
+
+void AutowarePlanningDataAnalyzerNode::close_evaluation_bag_writer()
+{
+  if (!evaluation_bag_writer_) {
+    return;
+  }
+
+  try {
+    evaluation_bag_writer_->close();
+    RCLCPP_INFO(get_logger(), "Evaluation bag writer closed successfully");
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(get_logger(), "Error closing evaluation bag writer: %s", e.what());
+  }
+  evaluation_bag_writer_.reset();
+}
+
+void AutowarePlanningDataAnalyzerNode::merge_bags(
+  const std::vector<std::filesystem::path> & input_bags,
+  const std::filesystem::path & output_bag) const
+{
+  rosbag2_cpp::Writer writer;
+  const rosbag2_storage::StorageOptions storage_options{output_bag.string(), "mcap"};
+  const rosbag2_cpp::ConverterOptions converter_options{
+    rmw_get_serialization_format(), rmw_get_serialization_format()};
+  writer.open(storage_options, converter_options);
+
+  std::set<std::string> added_topics;
+  std::vector<rosbag2_cpp::Reader> readers(input_bags.size());
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> next_messages(
+    input_bags.size());
+
+  for (size_t i = 0; i < input_bags.size(); ++i) {
+    readers[i].open(input_bags[i].string());
+
+    for (const auto & topic_metadata : readers[i].get_all_topics_and_types()) {
+      if (added_topics.insert(topic_metadata.name).second) {
+        writer.create_topic(topic_metadata);
+      }
+    }
+
+    if (readers[i].has_next()) {
+      next_messages[i] = readers[i].read_next();
+    }
+  }
+
+  while (true) {
+    size_t selected_index = input_bags.size();
+    uint64_t selected_timestamp = std::numeric_limits<uint64_t>::max();
+
+    for (size_t i = 0; i < next_messages.size(); ++i) {
+      if (!next_messages[i]) {
+        continue;
+      }
+
+      const auto timestamp = get_timestamp_ns(*next_messages[i]);
+      if (selected_index == input_bags.size() || timestamp < selected_timestamp) {
+        selected_index = i;
+        selected_timestamp = timestamp;
+      }
+    }
+
+    if (selected_index == input_bags.size()) {
+      break;
+    }
+
+    writer.write(next_messages[selected_index]);
+    if (readers[selected_index].has_next()) {
+      next_messages[selected_index] = readers[selected_index].read_next();
+    } else {
+      next_messages[selected_index].reset();
+    }
+  }
+
+  writer.close();
+}
+
+void AutowarePlanningDataAnalyzerNode::replace_input_bag_with_merged_evaluation()
+{
+  if (
+    evaluation_metrics_bag_path_.empty() ||
+    !std::filesystem::exists(evaluation_metrics_bag_path_)) {
+    return;
+  }
+
+  const std::filesystem::path input_bag_path(bag_path_);
+  const std::filesystem::path temp_root = evaluation_metrics_bag_path_.parent_path();
+  const std::filesystem::path merged_bag_path =
+    temp_root / (input_bag_path.filename().string() + ".tmp");
+  const std::filesystem::path backup_bag_path =
+    temp_root / (input_bag_path.filename().string() + ".bak");
+
+  const auto move_path =
+    [](const std::filesystem::path & source, const std::filesystem::path & target) {
+      if (std::filesystem::exists(target)) {
+        std::filesystem::remove_all(target);
+      }
+
+      try {
+        std::filesystem::rename(source, target);
+      } catch (const std::filesystem::filesystem_error &) {
+        std::filesystem::copy(
+          source, target,
+          std::filesystem::copy_options::recursive |
+            std::filesystem::copy_options::overwrite_existing);
+        std::filesystem::remove_all(source);
+      }
+    };
+
+  if (std::filesystem::exists(merged_bag_path)) {
+    std::filesystem::remove_all(merged_bag_path);
+  }
+  if (std::filesystem::exists(backup_bag_path)) {
+    std::filesystem::remove_all(backup_bag_path);
+  }
+
+  try {
+    merge_bags({input_bag_path, evaluation_metrics_bag_path_}, merged_bag_path);
+    move_path(input_bag_path, backup_bag_path);
+
+    try {
+      move_path(merged_bag_path, input_bag_path);
+    } catch (...) {
+      move_path(backup_bag_path, input_bag_path);
+      throw;
+    }
+
+    std::filesystem::remove_all(backup_bag_path);
+    std::filesystem::remove_all(evaluation_metrics_bag_path_);
+  } catch (...) {
+    if (std::filesystem::exists(merged_bag_path)) {
+      std::filesystem::remove_all(merged_bag_path);
+    }
+    if (std::filesystem::exists(backup_bag_path)) {
+      std::filesystem::remove_all(backup_bag_path);
+    }
+    if (std::filesystem::exists(evaluation_metrics_bag_path_)) {
+      std::filesystem::remove_all(evaluation_metrics_bag_path_);
+    }
+    throw;
   }
 }
 
@@ -174,10 +330,22 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   tf2_msgs::msg::TFMessage tf_static_msg;
   std::vector<std::pair<tf2_msgs::msg::TFMessage, rclcpp::Time>> tf_messages;
 
+  bool bag_time_initialized = false;
+  rclcpp::Time bag_start_time(0, 0, RCL_ROS_TIME);
+  rclcpp::Time bag_end_time(0, 0, RCL_ROS_TIME);
+
   // Quick scan for route and tf messages
   while (bag_reader_.has_next() && rclcpp::ok()) {
     auto serialized_message = bag_reader_.read_next();
     const auto & topic_name = serialized_message->topic_name;
+    const rclcpp::Time message_time(get_timestamp_ns(*serialized_message));
+    if (!bag_time_initialized || message_time < bag_start_time) {
+      bag_start_time = message_time;
+    }
+    if (!bag_time_initialized || message_time > bag_end_time) {
+      bag_end_time = message_time;
+    }
+    bag_time_initialized = true;
 
     if (topic_name == map_topic_name_) {
       try {
@@ -362,12 +530,15 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
     }
   }
 
-  // Write tf_static at the beginning if available
+  if (!bag_time_initialized) {
+    bag_start_time = start_time;
+    bag_end_time = end_time;
+  }
+
   if (
-    !tf_static_msg.transforms.empty() && evaluation_bag_writer_ && start_time.seconds() > 0 &&
-    end_time.seconds() > 0) {
-    // Use start_time so timestamps align with rest of bag (not 0 which breaks Lichtblick)
-    rclcpp::Time tf_time = start_time;
+    !tf_static_msg.transforms.empty() && evaluation_bag_writer_ && bag_start_time.seconds() > 0 &&
+    bag_end_time.seconds() > 0) {
+    rclcpp::Time tf_time = bag_start_time;
 
     // Set timestamps in the transforms to start_time
     tf2_msgs::msg::TFMessage timestamped_tf_static = tf_static_msg;
@@ -378,8 +549,11 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
     evaluation_bag_writer_->write(timestamped_tf_static, "/tf_static", tf_time);
   }
 
-  // Write map and route markers with start_time (not 0)
-  write_map_and_route_markers_to_bag(start_time);
+  write_map_and_route_markers_to_bag(bag_start_time);
+
+  close_evaluation_bag_writer();
+  bag_reader_.close();
+  replace_input_bag_with_merged_evaluation();
 
   RCLCPP_INFO(get_logger(), "Evaluation complete");
   rclcpp::shutdown();

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -449,9 +449,12 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
           "Invalid open_loop.gt_source_mode: " + gt_source_mode_ +
           ". Expected 'kinematic_state' or 'gt_trajectory'.");
       }
+      const auto evaluation_horizons =
+        get_or_declare_parameter<std::vector<double>>(*this, "open_loop.evaluation_horizons");
       OpenLoopEvaluator evaluator(get_logger(), route_handler_, gt_mode, gt_sync_tolerance_ms_);
       evaluator.set_json_output_dir(output_dir_path.string());
       evaluator.set_metric_variant(open_loop_metric_variant);
+      evaluator.set_evaluation_horizons(evaluation_horizons);
       auto times =
         evaluator.run_evaluation_from_bag(bag_path_, evaluation_bag_writer_.get(), topic_names);
       start_time = times.first;

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -439,6 +439,8 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
 
   switch (evaluation_mode_) {
     case EvaluationMode::OPEN_LOOP: {
+      const auto open_loop_metric_variant =
+        get_or_declare_parameter<std::string>(*this, "open_loop.metric_variant");
       OpenLoopEvaluator::GTSourceMode gt_mode = OpenLoopEvaluator::GTSourceMode::KINEMATIC_STATE;
       if (gt_source_mode_ == "gt_trajectory") {
         gt_mode = OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY;
@@ -449,6 +451,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       }
       OpenLoopEvaluator evaluator(get_logger(), route_handler_, gt_mode, gt_sync_tolerance_ms_);
       evaluator.set_json_output_dir(output_dir_path.string());
+      evaluator.set_metric_variant(open_loop_metric_variant);
       auto times =
         evaluator.run_evaluation_from_bag(bag_path_, evaluation_bag_writer_.get(), topic_names);
       start_time = times.first;

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -18,6 +18,7 @@
 #include "bag_handler.hpp"
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/writer.hpp"
+#include "serialized_bag_message.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
@@ -30,6 +31,7 @@
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -54,6 +56,11 @@ private:
   enum class EvaluationMode { OPEN_LOOP, OR_SCENE };
 
   void setup_evaluation_bag_writer();
+  void close_evaluation_bag_writer();
+  void merge_bags(
+    const std::vector<std::filesystem::path> & input_bags,
+    const std::filesystem::path & output_bag) const;
+  void replace_input_bag_with_merged_evaluation();
   void run_evaluation();
   void write_map_and_route_markers_to_bag(const rclcpp::Time & reference_time);
   void create_route_markers(visualization_msgs::msg::MarkerArray & marker_array) const;
@@ -84,6 +91,7 @@ private:
 
   EvaluationMode evaluation_mode_;
   std::string bag_path_;
+  std::filesystem::path evaluation_metrics_bag_path_;
 
   rclcpp::TimerBase::SharedPtr map_check_timer_;
 

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -17,6 +17,7 @@
 
 #include "buffer.hpp"
 #include "data_types.hpp"
+#include "serialized_bag_message.hpp"
 
 #include <rclcpp/serialization.hpp>
 #include <rosbag2_storage/serialized_bag_message.hpp>
@@ -314,7 +315,7 @@ void process_and_append_message(
 
     // Override header timestamp with bag timestamp if option is enabled
     set_header_timestamp_if_needed(
-      msg, use_bag_timestamp, rclcpp::Time(serialized_message->time_stamp));
+      msg, use_bag_timestamp, rclcpp::Time(get_timestamp_ns(*serialized_message)));
 
     bag_data->append_message<MessageType>(topic_key, msg);
   } catch (const std::exception & e) {

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -15,6 +15,7 @@
 #include "base_evaluator.hpp"
 
 #include "metrics/trajectory_metrics.hpp"
+#include "serialized_bag_message.hpp"
 
 #include <rclcpp/serialization.hpp>
 #include <rosbag2_cpp/reader.hpp>
@@ -55,7 +56,7 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
   while (bag_reader.has_next() && rclcpp::ok()) {
     auto serialized_message = bag_reader.read_next();
     const auto & topic_name = serialized_message->topic_name;
-    rclcpp::Time msg_time(serialized_message->time_stamp);
+    rclcpp::Time msg_time(get_timestamp_ns(*serialized_message));
 
     // Update time range
     if (msg_time < bag_start_time) bag_start_time = msg_time;

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -133,8 +133,8 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
 
 void BaseEvaluator::save_json_results(
   const nlohmann::json & json_output, const std::string & bag_path,
-  const std::string & evaluation_mode, const std::string & output_filename,
-  bool add_timestamp) const
+  const std::string & evaluation_mode, const std::string & output_filename, bool add_timestamp,
+  bool include_evaluation_info) const
 {
   std::filesystem::path output_path;
   if (!json_output_dir_.empty()) {
@@ -168,23 +168,50 @@ void BaseEvaluator::save_json_results(
     json_path = json_path.parent_path() / filename;
   }
 
-  // Create mutable copy to add evaluation info
-  nlohmann::json json_with_info = json_output;
+  nlohmann::json json_to_write = json_output;
+  if (include_evaluation_info) {
+    json_to_write["evaluation_info"]["timestamp"] = timestamp_string;
+    json_to_write["evaluation_info"]["bag_path"] = bag_path;
+    json_to_write["evaluation_info"]["evaluation_mode"] = evaluation_mode;
+  }
 
-  // Add evaluation info
-  json_with_info["evaluation_info"]["timestamp"] = timestamp_string;
-  json_with_info["evaluation_info"]["bag_path"] = bag_path;
-  json_with_info["evaluation_info"]["evaluation_mode"] = evaluation_mode;
-
-  // Write JSON file
   std::ofstream json_file(json_path);
   if (json_file.is_open()) {
-    json_file << json_with_info.dump(2);  // Pretty print with 2 spaces
+    json_file << json_to_write.dump(2);  // Pretty print with 2 spaces
     json_file.close();
     RCLCPP_INFO(logger_, "JSON results saved to: %s", json_path.c_str());
   } else {
     RCLCPP_ERROR(logger_, "Failed to save JSON results to: %s", json_path.c_str());
   }
+}
+
+void BaseEvaluator::save_jsonl_results(
+  const nlohmann::json & results_array, const std::string & output_filename) const
+{
+  std::filesystem::path output_path;
+  if (!json_output_dir_.empty()) {
+    output_path = std::filesystem::path(json_output_dir_) / output_filename;
+  } else {
+    std::string expanded_path = "~/" + output_filename;
+    if (!expanded_path.empty() && expanded_path[0] == '~') {
+      const char * home = std::getenv("HOME");
+      if (home) {
+        expanded_path = std::string(home) + expanded_path.substr(1);
+      }
+    }
+    output_path = expanded_path;
+  }
+
+  std::ofstream out(output_path);
+  if (!out.is_open()) {
+    RCLCPP_ERROR(logger_, "Failed to save JSONL results to: %s", output_path.c_str());
+    return;
+  }
+  for (const auto & obj : results_array) {
+    out << obj.dump() << '\n';
+  }
+  out.close();
+  RCLCPP_INFO(logger_, "JSONL results saved to: %s", output_path.c_str());
 }
 
 void BaseEvaluator::write_tf_static_to_bag(

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -132,36 +132,46 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
 
 void BaseEvaluator::save_json_results(
   const nlohmann::json & json_output, const std::string & bag_path,
-  const std::string & evaluation_mode, const std::string & output_filename) const
+  const std::string & evaluation_mode, const std::string & output_filename,
+  bool add_timestamp) const
 {
-  // TODO(go-sakayori): make output directory configurable
-  const std::string json_output_path = "~/" + output_filename + ".json";
-  std::string expanded_path = json_output_path;
+  std::filesystem::path output_path;
+  if (!json_output_dir_.empty()) {
+    output_path = std::filesystem::path(json_output_dir_) / output_filename;
+  } else {
+    const std::string json_output_path = "~/" + output_filename;
+    std::string expanded_path = json_output_path;
 
-  // Expand home directory if needed
-  if (expanded_path[0] == '~') {
-    const char * home = std::getenv("HOME");
-    if (home) {
-      expanded_path = std::string(home) + expanded_path.substr(1);
+    // Expand home directory if needed
+    if (!expanded_path.empty() && expanded_path[0] == '~') {
+      const char * home = std::getenv("HOME");
+      if (home) {
+        expanded_path = std::string(home) + expanded_path.substr(1);
+      }
     }
+    output_path = expanded_path;
   }
 
-  // Add timestamp to filename
-  auto now = std::chrono::system_clock::now();
-  auto time_t = std::chrono::system_clock::to_time_t(now);
-  std::stringstream timestamp_ss;
-  timestamp_ss << std::put_time(std::localtime(&time_t), "%Y%m%d_%H%M%S");
+  std::filesystem::path json_path(output_path);
+  std::string timestamp_string;
+  if (add_timestamp) {
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    std::stringstream timestamp_ss;
+    timestamp_ss << std::put_time(std::localtime(&time_t), "%Y%m%d_%H%M%S");
+    timestamp_string = timestamp_ss.str();
 
-  // Create filename with timestamp
-  std::filesystem::path json_path(expanded_path);
-  std::string filename = json_path.stem().string() + "_" + timestamp_ss.str() + ".json";
-  json_path = json_path.parent_path() / filename;
+    const std::string extension =
+      json_path.has_extension() ? json_path.extension().string() : ".json";
+    std::string filename = json_path.stem().string() + "_" + timestamp_string + extension;
+    json_path = json_path.parent_path() / filename;
+  }
 
   // Create mutable copy to add evaluation info
   nlohmann::json json_with_info = json_output;
 
   // Add evaluation info
-  json_with_info["evaluation_info"]["timestamp"] = timestamp_ss.str();
+  json_with_info["evaluation_info"]["timestamp"] = timestamp_string;
   json_with_info["evaluation_info"]["bag_path"] = bag_path;
   json_with_info["evaluation_info"]["evaluation_mode"] = evaluation_mode;
 

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -165,7 +165,16 @@ protected:
   void save_json_results(
     const nlohmann::json & json_output, const std::string & bag_path,
     const std::string & evaluation_mode, const std::string & output_filename = "evaluation_result",
-    bool add_timestamp = true) const;
+    bool add_timestamp = true, bool include_evaluation_info = true) const;
+
+  /**
+   * @brief Save an array of JSON objects as JSONL (one object per line)
+   * @param results_array Array of JSON objects, each with Result, Frame, Stamp
+   * @param output_filename Base filename for output (e.g.
+   * "time_step_based_trajectory_result.jsonl")
+   */
+  void save_jsonl_results(
+    const nlohmann::json & results_array, const std::string & output_filename) const;
 
   /**
    * @brief Write tf_static messages to evaluation bag

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -111,8 +111,13 @@ protected:
   {
     const auto topics = get_result_topics();
     for (const auto & [topic_name, topic_type] : topics) {
+#ifdef ROS_DISTRO_HUMBLE
       const auto topic_info =
         rosbag2_storage::TopicMetadata{topic_name, topic_type, rmw_get_serialization_format(), ""};
+#else
+      const auto topic_info = rosbag2_storage::TopicMetadata{
+        0, topic_name, topic_type, rmw_get_serialization_format(), {}, ""};
+#endif
       bag_writer.create_topic(topic_info);
     }
   }

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -100,6 +100,8 @@ public:
     const std::string & bag_path, rosbag2_cpp::Writer * evaluation_bag_writer,
     const TopicNames & topic_names) = 0;
 
+  void set_json_output_dir(const std::string & output_dir) { json_output_dir_ = output_dir; }
+
 protected:
   /**
    * @brief Create topics in bag writer
@@ -157,8 +159,8 @@ protected:
    */
   void save_json_results(
     const nlohmann::json & json_output, const std::string & bag_path,
-    const std::string & evaluation_mode,
-    const std::string & output_filename = "evaluation_result") const;
+    const std::string & evaluation_mode, const std::string & output_filename = "evaluation_result",
+    bool add_timestamp = true) const;
 
   /**
    * @brief Write tf_static messages to evaluation bag
@@ -192,6 +194,7 @@ protected:
 
   rclcpp::Logger logger_;
   std::shared_ptr<autoware::route_handler::RouteHandler> route_handler_;
+  std::string json_output_dir_;
 
   // For normalized timestamp calculation
   rclcpp::Time first_bag_timestamp_;

--- a/planning/autoware_planning_data_analyzer/src/buffer.cpp
+++ b/planning/autoware_planning_data_analyzer/src/buffer.cpp
@@ -156,9 +156,8 @@ auto Buffer<TFMessage>::get_closest(
 
   for (auto itr = msgs.begin(); itr != msgs.end(); ++itr) {
     if (!itr->transforms.empty()) {
-      const double diff = std::abs(
-        static_cast<double>(
-          rclcpp::Time(itr->transforms.front().header.stamp).nanoseconds() - target_time));
+      const double diff = std::abs(static_cast<double>(
+        rclcpp::Time(itr->transforms.front().header.stamp).nanoseconds() - target_time));
       if (diff < min_diff) {
         min_diff = diff;
         closest_itr = itr;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -283,8 +283,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     const auto preferred_lanes = route_handler->getPreferredLanelets();
     if (!preferred_lanes.empty()) {
       for (size_t i = 0; i < num_points; ++i) {
-        const auto arc_coordinates = lanelet::utils::getArcCoordinates(
-          preferred_lanes, trajectory.points[i].pose);
+        const auto arc_coordinates =
+          lanelet::utils::getArcCoordinates(preferred_lanes, trajectory.points[i].pose);
         metrics.lateral_deviations[i] = arc_coordinates.distance;
       }
     }

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -124,7 +124,7 @@ void OpenLoopEvaluator::evaluate(
     // Save to bag if writer provided
     if (bag_writer) {
       save_metrics_to_bag(metrics, eval_data, *bag_writer);
-      save_trajectory_point_metrics_to_bag(
+      save_trajectory_point_metrics_to_bag_with_variant(
         trajectory_metrics, *bag_writer, eval_data.synchronized_data->bag_timestamp);
     } else {
       RCLCPP_WARN(logger_, "No bag writer provided, metrics not saved to bag");
@@ -626,23 +626,23 @@ void OpenLoopEvaluator::save_metrics_to_bag(
 
   // ADE
   array_msg.data = metrics.ade;
-  bag_writer.write(array_msg, "/open_loop/metrics/ade", message_timestamp);
+  bag_writer.write(array_msg, metric_topic("ade"), message_timestamp);
 
   // FDE
   array_msg.data = metrics.displacement_errors;
-  bag_writer.write(array_msg, "/open_loop/metrics/fde", message_timestamp);
+  bag_writer.write(array_msg, metric_topic("fde"), message_timestamp);
 
   // Lateral deviations array
   array_msg.data = metrics.lateral_deviations;
-  bag_writer.write(array_msg, "/open_loop/metrics/lateral_deviation", message_timestamp);
+  bag_writer.write(array_msg, metric_topic("lateral_deviation"), message_timestamp);
 
   // Longitudinal deviations array
   array_msg.data = metrics.longitudinal_deviations;
-  bag_writer.write(array_msg, "/open_loop/metrics/longitudinal_deviation", message_timestamp);
+  bag_writer.write(array_msg, metric_topic("longitudinal_deviation"), message_timestamp);
 
   // TTC values array
   array_msg.data = metrics.ttc;
-  bag_writer.write(array_msg, "/open_loop/metrics/ttc", message_timestamp);
+  bag_writer.write(array_msg, metric_topic("ttc"), message_timestamp);
 
   save_dlr_style_result_to_bag(metrics, eval_data, bag_writer);
 
@@ -651,8 +651,75 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   gt_traj_msg.header.stamp = message_timestamp;
 
   if (!gt_traj_msg.points.empty()) {
-    bag_writer.write(gt_traj_msg, "/evaluation/compared_trajectory", message_timestamp);
+    bag_writer.write(gt_traj_msg, compared_trajectory_topic(), message_timestamp);
   }
+}
+
+void OpenLoopEvaluator::save_trajectory_point_metrics_to_bag_with_variant(
+  const metrics::TrajectoryPointMetrics & metrics, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & normalized_timestamp) const
+{
+  {
+    std_msgs::msg::Float64MultiArray msg;
+    msg.data = metrics.lateral_accelerations;
+    bag_writer.write(msg, trajectory_metric_topic("lateral_accelerations"), normalized_timestamp);
+  }
+
+  {
+    std_msgs::msg::Float64MultiArray msg;
+    msg.data = metrics.longitudinal_jerks;
+    bag_writer.write(msg, trajectory_metric_topic("longitudinal_jerks"), normalized_timestamp);
+  }
+
+  {
+    std_msgs::msg::Float64MultiArray msg;
+    msg.data = metrics.ttc_values;
+    bag_writer.write(msg, trajectory_metric_topic("ttc_values"), normalized_timestamp);
+  }
+
+  {
+    std_msgs::msg::Float64MultiArray msg;
+    msg.data = metrics.lateral_deviations;
+    bag_writer.write(msg, trajectory_metric_topic("lateral_deviations"), normalized_timestamp);
+  }
+
+  {
+    std_msgs::msg::Float64MultiArray msg;
+    msg.data = metrics.travel_distances;
+    bag_writer.write(msg, trajectory_metric_topic("travel_distances"), normalized_timestamp);
+  }
+}
+
+std::string OpenLoopEvaluator::metric_topic(const std::string & metric_name) const
+{
+  if (metric_variant_.empty()) {
+    return "/open_loop/metrics/" + metric_name;
+  }
+  return "/open_loop/metrics/" + metric_variant_ + "/" + metric_name;
+}
+
+std::string OpenLoopEvaluator::trajectory_metric_topic(const std::string & metric_name) const
+{
+  if (metric_variant_.empty()) {
+    return "/trajectory/" + metric_name;
+  }
+  return "/trajectory/" + metric_variant_ + "/" + metric_name;
+}
+
+std::string OpenLoopEvaluator::compared_trajectory_topic() const
+{
+  if (metric_variant_.empty()) {
+    return "/evaluation/compared_trajectory";
+  }
+  return "/evaluation/compared_trajectory/" + metric_variant_;
+}
+
+std::string OpenLoopEvaluator::dlr_result_topic() const
+{
+  if (metric_variant_.empty()) {
+    return "/driving_log_replayer/time_step_based_trajectory/results";
+  }
+  return "/driving_log_replayer/time_step_based_trajectory/" + metric_variant_ + "/results";
 }
 
 void OpenLoopEvaluator::calculate_summary()
@@ -861,27 +928,25 @@ void OpenLoopEvaluator::save_dlr_style_result_to_bag(
 
   std_msgs::msg::String result_msg;
   result_msg.data = result_json.dump();
-  bag_writer.write(
-    result_msg, "/driving_log_replayer/time_step_based_trajectory/results",
-    trajectory_data->bag_timestamp);
+  bag_writer.write(result_msg, dlr_result_topic(), trajectory_data->bag_timestamp);
 }
 
 std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_topics() const
 {
   return {
-    {"/driving_log_replayer/time_step_based_trajectory/results", "std_msgs/msg/String"},
-    {"/open_loop/metrics/ade", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/fde", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/ttc", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/lateral_deviation", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/longitudinal_deviation", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/trajectory_lateral_acceleration", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/trajectory_longitudinal_jerk", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/trajectory_ttc_values", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/trajectory_lateral_deviations", "std_msgs/msg/Float64MultiArray"},
-    {"/open_loop/metrics/trajectory_travel_distances", "std_msgs/msg/Float64MultiArray"},
+    {dlr_result_topic(), "std_msgs/msg/String"},
+    {metric_topic("ade"), "std_msgs/msg/Float64MultiArray"},
+    {metric_topic("fde"), "std_msgs/msg/Float64MultiArray"},
+    {metric_topic("ttc"), "std_msgs/msg/Float64MultiArray"},
+    {metric_topic("lateral_deviation"), "std_msgs/msg/Float64MultiArray"},
+    {metric_topic("longitudinal_deviation"), "std_msgs/msg/Float64MultiArray"},
+    {trajectory_metric_topic("lateral_accelerations"), "std_msgs/msg/Float64MultiArray"},
+    {trajectory_metric_topic("longitudinal_jerks"), "std_msgs/msg/Float64MultiArray"},
+    {trajectory_metric_topic("ttc_values"), "std_msgs/msg/Float64MultiArray"},
+    {trajectory_metric_topic("lateral_deviations"), "std_msgs/msg/Float64MultiArray"},
+    {trajectory_metric_topic("travel_distances"), "std_msgs/msg/Float64MultiArray"},
     {"/planning/trajectory", "autoware_planning_msgs/msg/Trajectory"},
-    {"/evaluation/compared_trajectory", "autoware_planning_msgs/msg/Trajectory"},
+    {compared_trajectory_topic(), "autoware_planning_msgs/msg/Trajectory"},
     {"/perception/object_recognition/objects", "autoware_perception_msgs/msg/PredictedObjects"},
     {"/tf", "tf2_msgs/msg/TFMessage"},
     {"/tf_static", "tf2_msgs/msg/TFMessage"}};

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -25,6 +25,7 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
@@ -32,9 +33,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -641,6 +644,8 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   array_msg.data = metrics.ttc;
   bag_writer.write(array_msg, "/open_loop/metrics/ttc", message_timestamp);
 
+  save_dlr_style_result_to_bag(metrics, eval_data, bag_writer);
+
   // Save the precomputed ground truth trajectory directly
   autoware_planning_msgs::msg::Trajectory gt_traj_msg = ground_truth_trajectory;
   gt_traj_msg.header.stamp = message_timestamp;
@@ -806,9 +811,65 @@ nlohmann::json OpenLoopEvaluator::get_detailed_results_as_json() const
   return j;
 }
 
+std::string OpenLoopEvaluator::format_horizon_key(double seconds) const
+{
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(3) << seconds;
+  auto formatted = stream.str();
+  formatted.erase(formatted.find_last_not_of('0') + 1);
+  if (!formatted.empty() && formatted.back() == '.') {
+    formatted.pop_back();
+  }
+  if (formatted.empty()) {
+    formatted = "0";
+  }
+  return formatted + "s";
+}
+
+void OpenLoopEvaluator::save_dlr_style_result_to_bag(
+  const OpenLoopTrajectoryMetrics & metrics, const EvaluationData & eval_data,
+  rosbag2_cpp::Writer & bag_writer)
+{
+  const auto & trajectory_data = eval_data.synchronized_data;
+  if (!trajectory_data || !trajectory_data->trajectory) {
+    return;
+  }
+
+  nlohmann::json result_json;
+  const auto & trajectory_points = trajectory_data->trajectory->points;
+  const size_t point_count =
+    std::min({trajectory_points.size(), metrics.ade.size(), metrics.displacement_errors.size()});
+  const bool has_frame = point_count > 0;
+
+  result_json["Result"]["Success"] = has_frame;
+  result_json["Result"]["Summary"] =
+    has_frame ? "ADE/FDE metrics generated" : "ADE/FDE metrics unavailable";
+  result_json["Stamp"]["System"] = trajectory_data->bag_timestamp.seconds();
+  result_json["Stamp"]["ROS"] = trajectory_data->timestamp.seconds();
+
+  for (size_t index = 0; index < point_count; ++index) {
+    const auto horizon_sec =
+      rclcpp::Duration(trajectory_points.at(index).time_from_start).seconds();
+    const auto horizon_key = format_horizon_key(horizon_sec);
+    result_json["Frame"][horizon_key]["ADE"] = metrics.ade.at(index);
+    result_json["Frame"][horizon_key]["FDE"] = metrics.displacement_errors.at(index);
+  }
+
+  if (!result_json.contains("Frame")) {
+    result_json["Frame"] = nlohmann::json::object();
+  }
+
+  std_msgs::msg::String result_msg;
+  result_msg.data = result_json.dump();
+  bag_writer.write(
+    result_msg, "/driving_log_replayer/time_step_based_trajectory/results",
+    trajectory_data->bag_timestamp);
+}
+
 std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_topics() const
 {
   return {
+    {"/driving_log_replayer/time_step_based_trajectory/results", "std_msgs/msg/String"},
     {"/open_loop/metrics/ade", "std_msgs/msg/Float64MultiArray"},
     {"/open_loop/metrics/fde", "std_msgs/msg/Float64MultiArray"},
     {"/open_loop/metrics/ttc", "std_msgs/msg/Float64MultiArray"},

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -121,18 +121,8 @@ void OpenLoopEvaluator::evaluate(
     // Save to bag if writer provided
     if (bag_writer) {
       save_metrics_to_bag(metrics, eval_data, *bag_writer);
-
-      // Calculate normalized timestamp for trajectory point metrics
-      if (!first_bag_timestamp_set_) {
-        first_bag_timestamp_ = eval_data.synchronized_data->bag_timestamp;
-        first_bag_timestamp_set_ = true;
-      }
-      const auto relative_duration =
-        eval_data.synchronized_data->bag_timestamp - first_bag_timestamp_;
-      const rclcpp::Time normalized_timestamp =
-        rclcpp::Time(0, 0, RCL_ROS_TIME) + relative_duration;
-
-      save_trajectory_point_metrics_to_bag(trajectory_metrics, *bag_writer, normalized_timestamp);
+      save_trajectory_point_metrics_to_bag(
+        trajectory_metrics, *bag_writer, eval_data.synchronized_data->bag_timestamp);
     } else {
       RCLCPP_WARN(logger_, "No bag writer provided, metrics not saved to bag");
     }
@@ -624,81 +614,39 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   const OpenLoopTrajectoryMetrics & metrics, const EvaluationData & eval_data,
   rosbag2_cpp::Writer & bag_writer)
 {
-  const auto & trajectory_data = eval_data.synchronized_data;
   const auto & ground_truth_trajectory = eval_data.ground_truth_trajectory;
-
-  // Use a normalized timestamp for bag writing to ensure proper duration
-  // Start from 0 and use relative times from the first synchronized data point
-  if (!first_bag_timestamp_set_) {
-    first_bag_timestamp_ = trajectory_data->bag_timestamp;
-    first_bag_timestamp_set_ = true;
-  }
-
-  // Calculate relative timestamp from the first data point
-  const auto relative_duration = trajectory_data->bag_timestamp - first_bag_timestamp_;
-  const rclcpp::Time normalized_timestamp = rclcpp::Time(0, 0, RCL_ROS_TIME) + relative_duration;
+  const auto & trajectory_data = eval_data.synchronized_data;
+  const rclcpp::Time message_timestamp = trajectory_data->bag_timestamp;
 
   // Write point-wise metrics as Float64MultiArray
   std_msgs::msg::Float64MultiArray array_msg;
 
   // ADE
   array_msg.data = metrics.ade;
-  bag_writer.write(array_msg, "/open_loop/metrics/ade", normalized_timestamp);
+  bag_writer.write(array_msg, "/open_loop/metrics/ade", message_timestamp);
 
   // FDE
   array_msg.data = metrics.displacement_errors;
-  bag_writer.write(array_msg, "/open_loop/metrics/fde", normalized_timestamp);
+  bag_writer.write(array_msg, "/open_loop/metrics/fde", message_timestamp);
 
   // Lateral deviations array
   array_msg.data = metrics.lateral_deviations;
-  bag_writer.write(array_msg, "/open_loop/metrics/lateral_deviation", normalized_timestamp);
+  bag_writer.write(array_msg, "/open_loop/metrics/lateral_deviation", message_timestamp);
 
   // Longitudinal deviations array
   array_msg.data = metrics.longitudinal_deviations;
-  bag_writer.write(array_msg, "/open_loop/metrics/longitudinal_deviation", normalized_timestamp);
+  bag_writer.write(array_msg, "/open_loop/metrics/longitudinal_deviation", message_timestamp);
 
   // TTC values array
   array_msg.data = metrics.ttc;
-  bag_writer.write(array_msg, "/open_loop/metrics/ttc", normalized_timestamp);
-
-  // Write minimal TF for visualization (map -> base_link)
-  if (trajectory_data->kinematic_state) {
-    tf2_msgs::msg::TFMessage tf_msg;
-    geometry_msgs::msg::TransformStamped transform;
-
-    // Use the normalized timestamp for consistency
-    transform.header.stamp = normalized_timestamp;
-    transform.header.frame_id = "map";
-    transform.child_frame_id = "base_link";
-
-    // Use kinematic state pose as transform
-    transform.transform.translation.x = trajectory_data->kinematic_state->pose.pose.position.x;
-    transform.transform.translation.y = trajectory_data->kinematic_state->pose.pose.position.y;
-    transform.transform.translation.z = trajectory_data->kinematic_state->pose.pose.position.z;
-    transform.transform.rotation = trajectory_data->kinematic_state->pose.pose.orientation;
-
-    tf_msg.transforms.push_back(transform);
-
-    // Write TF with the normalized timestamp for consistency
-    bag_writer.write(tf_msg, "/tf", normalized_timestamp);
-  }
-
-  // Save the original trajectory using base class method
-  write_trajectory_to_bag(trajectory_data, bag_writer, normalized_timestamp);
+  bag_writer.write(array_msg, "/open_loop/metrics/ttc", message_timestamp);
 
   // Save the precomputed ground truth trajectory directly
   autoware_planning_msgs::msg::Trajectory gt_traj_msg = ground_truth_trajectory;
-  gt_traj_msg.header.stamp = normalized_timestamp;
+  gt_traj_msg.header.stamp = message_timestamp;
 
   if (!gt_traj_msg.points.empty()) {
-    bag_writer.write(gt_traj_msg, "/ground_truth/trajectory", normalized_timestamp);
-  }
-
-  // Save perception objects if available
-  if (trajectory_data->objects) {
-    autoware_perception_msgs::msg::PredictedObjects objects_msg = *(trajectory_data->objects);
-    objects_msg.header.stamp = normalized_timestamp;
-    bag_writer.write(objects_msg, "/perception/object_recognition/objects", normalized_timestamp);
+    bag_writer.write(gt_traj_msg, "/evaluation/compared_trajectory", message_timestamp);
   }
 }
 
@@ -872,7 +820,7 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     {"/open_loop/metrics/trajectory_lateral_deviations", "std_msgs/msg/Float64MultiArray"},
     {"/open_loop/metrics/trajectory_travel_distances", "std_msgs/msg/Float64MultiArray"},
     {"/planning/trajectory", "autoware_planning_msgs/msg/Trajectory"},
-    {"/ground_truth/trajectory", "autoware_planning_msgs/msg/Trajectory"},
+    {"/evaluation/compared_trajectory", "autoware_planning_msgs/msg/Trajectory"},
     {"/perception/object_recognition/objects", "autoware_perception_msgs/msg/PredictedObjects"},
     {"/tf", "tf2_msgs/msg/TFMessage"},
     {"/tf_static", "tf2_msgs/msg/TFMessage"}};

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -914,7 +914,10 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
     auto detailed_json = get_detailed_results_as_json();
 
     // Save using base class method
-    save_json_results(detailed_json, bag_path, "open_loop", "open_loop_evaluation_results");
+    save_json_results(
+      summary_json, bag_path, "open_loop", "time_step_based_trajectory_metric.json", false);
+    save_json_results(
+      detailed_json, bag_path, "open_loop", "time_step_based_trajectory_result.jsonl", false);
 
     // Log summary
     RCLCPP_INFO(logger_, "Open-loop evaluation summary:");

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -37,6 +37,8 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <optional>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -78,6 +80,59 @@ Statistics<Container> calculate_statistics(const Container & values)
   stats.std_dev = std::sqrt(variance / values.size());
 
   return stats;
+}
+
+static double compute_mean(const std::vector<double> & v)
+{
+  return v.empty() ? 0.0 : std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+}
+
+static double compute_std_dev(const std::vector<double> & v)
+{
+  if (v.size() < 2) return 0.0;
+  const double m = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+  double var = 0.0;
+  for (const double x : v) var += (x - m) * (x - m);
+  return std::sqrt(var / v.size());
+}
+
+static double compute_percentile(const std::vector<double> & sorted, double p)
+{
+  if (sorted.empty()) return 0.0;
+  if (sorted.size() == 1) return sorted[0];
+  const double idx = p * static_cast<double>(sorted.size() - 1);
+  const size_t lo = static_cast<size_t>(std::floor(idx));
+  const size_t hi = std::min(lo + 1, sorted.size() - 1);
+  const double frac = idx - static_cast<double>(lo);
+  return sorted[lo] * (1.0 - frac) + sorted[hi] * frac;
+}
+
+static void fill_horizon_json(
+  nlohmann::json & j, const std::vector<std::pair<std::string, HorizonMetrics>> & horizons,
+  size_t num_points)
+{
+  for (const auto & [key, hm] : horizons) {
+    auto & f = j[key];
+    f["Result"]["Total"] = "Success";
+    f["Result"]["Frame"] = "Success";
+    f["Info"]["ADE"] = hm.ade;
+    f["Info"]["FDE"] = hm.fde;
+    f["Info"]["average_lateral_deviation"] = hm.average_lateral_deviation;
+    f["Info"]["max_lateral_deviation"] = hm.max_lateral_deviation;
+    f["Info"]["average_longitudinal_deviation"] = hm.average_longitudinal_deviation;
+    f["Info"]["max_longitudinal_deviation"] = hm.max_longitudinal_deviation;
+    f["Info"]["min_ttc"] = hm.min_ttc;
+    if (key == "full") {
+      f["Info"]["num_points"] = num_points;
+    }
+  }
+}
+
+static std::string result_summary(bool has_frame, size_t num_points)
+{
+  if (has_frame) return "Open-loop trajectory metrics generated";
+  return num_points <= 1u ? "Too few trajectory points"
+                          : "Open-loop trajectory metrics unavailable";
 }
 
 // Constructor implementation moved to header file
@@ -133,10 +188,6 @@ void OpenLoopEvaluator::evaluate(
 
   // Calculate summary statistics
   calculate_summary();
-
-  RCLCPP_INFO(
-    logger_, "Overall: Mean ADE=%.3fm (±%.3fm), Mean FDE=%.3fm (±%.3fm)", summary_.mean_ade,
-    summary_.std_ade, summary_.mean_fde, summary_.std_fde);
 }
 
 std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evaluation_data(
@@ -145,8 +196,14 @@ std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evalua
   std::vector<EvaluationData> result;
 
   for (const auto & data : synchronized_data_list) {
-    // Skip if no trajectory available
-    if (!data->trajectory || data->trajectory->points.empty()) {
+    if (!data->trajectory) {
+      continue;
+    }
+
+    const size_t num_pts = data->trajectory->points.size();
+    if (num_pts <= 1u) {
+      // Include frame in output as failure (no metrics); do not skip.
+      result.push_back({data, autoware_planning_msgs::msg::Trajectory{}});
       continue;
     }
 
@@ -359,8 +416,17 @@ OpenLoopTrajectoryMetrics OpenLoopEvaluator::evaluate_trajectory(const Evaluatio
 
   metrics.num_points = trajectory.points.size();
   metrics.trajectory_timestamp = eval_data.synchronized_data->timestamp;
+  metrics.bag_timestamp = eval_data.synchronized_data->bag_timestamp;
 
-  if (metrics.num_points == 0) {
+  if (metrics.num_points <= 1u) {
+    if (metrics.num_points == 1u && !trajectory.points.empty()) {
+      metrics.trajectory_duration =
+        rclcpp::Duration(trajectory.points.back().time_from_start).seconds();
+    }
+    return metrics;
+  }
+
+  if (ground_truth_trajectory.points.size() != trajectory.points.size()) {
     return metrics;
   }
 
@@ -369,31 +435,49 @@ OpenLoopTrajectoryMetrics OpenLoopEvaluator::evaluate_trajectory(const Evaluatio
   metrics.longitudinal_deviations.resize(metrics.num_points, 0.0);
   metrics.displacement_errors.resize(metrics.num_points, 0.0);
   metrics.ground_truth_poses.resize(metrics.num_points);
-  metrics.ttc.resize(metrics.num_points, std::numeric_limits<double>::max());
   metrics.ade.resize(metrics.num_points, 0.0);
+  metrics.ttc.resize(metrics.num_points, std::numeric_limits<double>::max());
+
+  // Running accumulators for per-horizon aggregate metrics
+  std::vector<double> lat_prefix_sum(metrics.num_points);
+  std::vector<double> lon_prefix_sum(metrics.num_points);
+  std::vector<double> lat_running_abs_max(metrics.num_points);
+  std::vector<double> lon_running_abs_max(metrics.num_points);
+  std::vector<double> ttc_running_min(metrics.num_points);
 
   // Evaluate each trajectory point against precomputed ground truth
+  double displacement_sum = 0.0;
+  double lat_sum = 0.0;
+  double lon_sum = 0.0;
+  double lat_max = 0.0;
+  double lon_max = 0.0;
+  double ttc_min = std::numeric_limits<double>::max();
+
   for (size_t i = 0; i < metrics.num_points; ++i) {
     const auto & traj_point = trajectory.points[i];
     const auto & gt_pose = ground_truth_trajectory.points[i].pose;
 
-    // Store ground truth pose
     metrics.ground_truth_poses[i] = gt_pose;
 
-    // Calculate displacement error
     metrics.displacement_errors[i] =
       autoware_utils_geometry::calc_distance2d(traj_point.pose.position, gt_pose.position);
-    metrics.ade[i] =
-      std::accumulate(
-        metrics.displacement_errors.begin(), metrics.displacement_errors.begin() + i + 1, 0.0) /
-      (i + 1);
+    displacement_sum += metrics.displacement_errors[i];
+    metrics.ade[i] = displacement_sum / (i + 1);
 
-    // Calculate errors in vehicle coordinate frame
     const auto [longitudinal_error, lateral_error] =
       calculate_errors_in_vehicle_frame(traj_point.pose, gt_pose);
 
     metrics.longitudinal_deviations[i] = longitudinal_error;
     metrics.lateral_deviations[i] = lateral_error;
+
+    lat_sum += std::abs(lateral_error);
+    lon_sum += std::abs(longitudinal_error);
+    lat_max = std::max(lat_max, std::abs(lateral_error));
+    lon_max = std::max(lon_max, std::abs(longitudinal_error));
+    lat_prefix_sum[i] = lat_sum;
+    lon_prefix_sum[i] = lon_sum;
+    lat_running_abs_max[i] = lat_max;
+    lon_running_abs_max[i] = lon_max;
 
     // TTC calculation - using current objects from synchronized data
     // Note: This is a simplified approach using the objects from the current frame
@@ -419,7 +503,10 @@ OpenLoopTrajectoryMetrics OpenLoopEvaluator::evaluate_trajectory(const Evaluatio
       metrics.ttc[i] = ttc_at_point;
     }
     */
-    (void)objects_at_time;  // Suppress unused variable warning
+    (void)objects_at_time;
+
+    ttc_min = std::min(ttc_min, metrics.ttc[i]);
+    ttc_running_min[i] = ttc_min;
   }
 
   // Calculate trajectory duration
@@ -433,6 +520,39 @@ OpenLoopTrajectoryMetrics OpenLoopEvaluator::evaluate_trajectory(const Evaluatio
   if (!trajectory.points.empty()) {
     metrics.evaluation_end_time = eval_data.synchronized_data->timestamp +
                                   rclcpp::Duration(trajectory.points.back().time_from_start);
+  }
+
+  // Pre-compute per-horizon metrics
+  constexpr double kHorizonToleranceSec = 0.1;
+  auto compute_horizon = [&](size_t cutoff) -> HorizonMetrics {
+    const double n = static_cast<double>(cutoff + 1);
+    return {metrics.ade[cutoff],        metrics.displacement_errors[cutoff],
+            lat_prefix_sum[cutoff] / n, lat_running_abs_max[cutoff],
+            lon_prefix_sum[cutoff] / n, lon_running_abs_max[cutoff],
+            ttc_running_min[cutoff]};
+  };
+
+  if (metrics.num_points > 1u) {
+    metrics.horizon_results.emplace_back("full", compute_horizon(metrics.num_points - 1));
+  }
+
+  for (const double horizon : evaluation_horizons_) {
+    std::optional<size_t> cutoff;
+    for (size_t i = 0; i < metrics.num_points; ++i) {
+      const double t = rclcpp::Duration(trajectory.points[i].time_from_start).seconds();
+      if (t <= horizon + 1e-6) {
+        cutoff = i;
+      } else {
+        break;
+      }
+    }
+    if (!cutoff.has_value()) continue;
+    const double actual_t = rclcpp::Duration(trajectory.points[*cutoff].time_from_start).seconds();
+    if (horizon - actual_t > kHorizonToleranceSec) continue;
+
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(1) << horizon << "s";
+    metrics.horizon_results.emplace_back(oss.str(), compute_horizon(*cutoff));
   }
 
   return metrics;
@@ -673,12 +793,6 @@ void OpenLoopEvaluator::save_trajectory_point_metrics_to_bag_with_variant(
 
   {
     std_msgs::msg::Float64MultiArray msg;
-    msg.data = metrics.ttc_values;
-    bag_writer.write(msg, trajectory_metric_topic("ttc_values"), normalized_timestamp);
-  }
-
-  {
-    std_msgs::msg::Float64MultiArray msg;
     msg.data = metrics.lateral_deviations;
     bag_writer.write(msg, trajectory_metric_topic("lateral_deviations"), normalized_timestamp);
   }
@@ -736,17 +850,16 @@ void OpenLoopEvaluator::calculate_summary()
   std::vector<double> lateral_dev_values;
 
   for (const auto & metrics : metrics_list_) {
-    // All trajectories in metrics_list_ have valid ground truth (guaranteed by
-    // prepare_evaluation_data) Calculate ADE (average displacement error) from point-wise errors
+    if (metrics.num_points <= 1u) {
+      continue;
+    }
     const double ade = metrics.ade.empty() ? 0.0 : metrics.ade.back();
     ade_values.push_back(ade);
 
-    // FDE is the last displacement error
     const double fde =
       metrics.displacement_errors.empty() ? 0.0 : metrics.displacement_errors.back();
     fde_values.push_back(fde);
 
-    // Calculate mean lateral deviation
     const double mean_lateral_dev =
       std::accumulate(metrics.lateral_deviations.begin(), metrics.lateral_deviations.end(), 0.0) /
       (metrics.lateral_deviations.empty() ? 1.0 : metrics.lateral_deviations.size());
@@ -793,104 +906,126 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
 {
   nlohmann::json j;
 
-  j["total_trajectories"] = summary_.total_trajectories;
-  j["valid_trajectories"] = summary_.valid_trajectories;
-  j["fully_valid_trajectories"] = summary_.fully_valid_trajectories;
-  j["mean_coverage_ratio"] = summary_.mean_coverage_ratio;
-  j["total_evaluation_duration_sec"] = summary_.total_evaluation_duration;
+  auto emit_metric = [&](
+                       const std::string & horizon_key, const std::string & metric_name,
+                       const std::string & desc, const std::vector<double> & vals) {
+    const std::string prefix = horizon_key + "/" + metric_name;
+    std::vector<double> sorted = vals;
+    std::sort(sorted.begin(), sorted.end());
+    j[prefix + "/description"] = desc;
+    j[prefix + "/mean"] = compute_mean(vals);
+    j[prefix + "/min"] = sorted.empty() ? 0.0 : sorted.front();
+    j[prefix + "/max"] = sorted.empty() ? 0.0 : sorted.back();
+    j[prefix + "/std"] = compute_std_dev(vals);
+    j[prefix + "/percentile_95"] = compute_percentile(sorted, 0.95);
+    j[prefix + "/percentile_99"] = compute_percentile(sorted, 0.99);
+  };
 
-  j["ade"]["mean"] = summary_.mean_ade;
-  j["ade"]["std"] = summary_.std_ade;
-  j["ade"]["max"] = summary_.max_ade;
+  std::set<std::string> all_keys;
+  for (const auto & m : metrics_list_) {
+    for (const auto & p : m.horizon_results) all_keys.insert(p.first);
+  }
+  for (const auto & tag : all_keys) {
+    std::vector<double> ade_vals, fde_vals;
+    std::vector<double> avg_lat_vals, max_lat_vals, avg_lon_vals, max_lon_vals;
+    std::vector<double> min_ttc_vals;
+    for (const auto & m : metrics_list_) {
+      const auto it = std::find_if(
+        m.horizon_results.begin(), m.horizon_results.end(),
+        [&tag](const auto & p) { return p.first == tag; });
+      if (it == m.horizon_results.end()) continue;
+      const auto & hm = it->second;
+      ade_vals.push_back(hm.ade);
+      fde_vals.push_back(hm.fde);
+      avg_lat_vals.push_back(hm.average_lateral_deviation);
+      max_lat_vals.push_back(hm.max_lateral_deviation);
+      avg_lon_vals.push_back(hm.average_longitudinal_deviation);
+      max_lon_vals.push_back(hm.max_longitudinal_deviation);
+      min_ttc_vals.push_back(hm.min_ttc);
+    }
 
-  j["fde"]["mean"] = summary_.mean_fde;
-  j["fde"]["std"] = summary_.std_fde;
-  j["fde"]["max"] = summary_.max_fde;
+    j[tag + "/count"] = ade_vals.size();
 
-  j["lateral_deviation"]["mean"] = summary_.mean_lateral_deviation;
-  j["lateral_deviation"]["std"] = summary_.std_lateral_deviation;
-  j["lateral_deviation"]["max"] = summary_.max_lateral_deviation;
+    emit_metric(tag, "ade", "Average Displacement Error within " + tag + " horizon [m]", ade_vals);
+    emit_metric(tag, "fde", "Final Displacement Error at " + tag + " horizon [m]", fde_vals);
+    emit_metric(
+      tag, "average_lateral_deviation", "Average lateral deviation within " + tag + " horizon [m]",
+      avg_lat_vals);
+    emit_metric(
+      tag, "max_lateral_deviation", "Max lateral deviation within " + tag + " horizon [m]",
+      max_lat_vals);
+    emit_metric(
+      tag, "average_longitudinal_deviation",
+      "Average longitudinal deviation within " + tag + " horizon [m]", avg_lon_vals);
+    emit_metric(
+      tag, "max_longitudinal_deviation",
+      "Max longitudinal deviation within " + tag + " horizon [m]", max_lon_vals);
+    emit_metric(
+      tag, "min_ttc", "Minimum Time To Collision within " + tag + " horizon [s]", min_ttc_vals);
+  }
 
   return j;
 }
 
 nlohmann::json OpenLoopEvaluator::get_detailed_results_as_json() const
 {
-  nlohmann::json j;
+  nlohmann::json results = nlohmann::json::array();
 
+  for (const auto & metrics : metrics_list_) {
+    const bool has_frame = !metrics.horizon_results.empty();
+    nlohmann::json entry;
+    entry["Result"]["Success"] = has_frame;
+    entry["Result"]["Summary"] = result_summary(has_frame, metrics.num_points);
+    entry["Stamp"]["System"] = metrics.bag_timestamp.seconds();
+    entry["Stamp"]["ROS"] = metrics.trajectory_timestamp.seconds();
+    entry["Frame"] = nlohmann::json::object();
+    fill_horizon_json(entry["Frame"], metrics.horizon_results, metrics.num_points);
+    results.push_back(entry);
+  }
+
+  nlohmann::json j;
+  j["results"] = results;
+  return j;
+}
+
+nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
+{
+  nlohmann::json j;
   j["summary"] = get_summary_as_json();
 
   nlohmann::json trajectories = nlohmann::json::array();
   for (size_t i = 0; i < metrics_list_.size(); ++i) {
-    const auto & metrics = metrics_list_[i];
+    const auto & m = metrics_list_[i];
     nlohmann::json traj;
 
-    traj["timestamp_sec"] = metrics.trajectory_timestamp.seconds();
-    traj["num_points"] = metrics.num_points;
-    traj["trajectory_duration_sec"] = metrics.trajectory_duration;
+    traj["timestamp_sec"] = m.trajectory_timestamp.seconds();
+    traj["bag_timestamp_sec"] = m.bag_timestamp.seconds();
+    traj["num_points"] = m.num_points;
+    traj["trajectory_duration_sec"] = m.trajectory_duration;
 
-    // Calculate aggregate metrics from point-wise data
-    const double ade = metrics.ade.empty() ? 0.0 : metrics.ade.back();
-    const double fde =
-      metrics.displacement_errors.empty() ? 0.0 : metrics.displacement_errors.back();
+    traj["ade"] = m.ade;
+    traj["displacement_errors"] = m.displacement_errors;
+    traj["lateral_deviations"] = m.lateral_deviations;
+    traj["longitudinal_deviations"] = m.longitudinal_deviations;
+    traj["ttc"] = m.ttc;
 
-    traj["ade"] = ade;
-    traj["fde"] = fde;
+    traj["horizon_results"] = nlohmann::json::object();
+    fill_horizon_json(traj["horizon_results"], m.horizon_results, m.num_points);
 
-    // Calculate lateral deviation statistics
-    if (!metrics.lateral_deviations.empty()) {
-      const double mean_lateral =
-        std::accumulate(metrics.lateral_deviations.begin(), metrics.lateral_deviations.end(), 0.0) /
-        metrics.lateral_deviations.size();
-      const double max_lateral =
-        *std::max_element(metrics.lateral_deviations.begin(), metrics.lateral_deviations.end());
-
-      traj["mean_lateral_deviation"] = std::abs(mean_lateral);
-      traj["max_lateral_deviation"] = std::abs(max_lateral);
-    }
-
-    // Calculate min TTC
-    const auto min_ttc_it = std::min_element(metrics.ttc.begin(), metrics.ttc.end());
-    const double min_ttc =
-      (min_ttc_it != metrics.ttc.end()) ? *min_ttc_it : std::numeric_limits<double>::max();
-    traj["min_ttc"] = min_ttc;
-
-    // Include point-wise data if needed
-    traj["lateral_deviations"] = metrics.lateral_deviations;
-    traj["displacement_errors"] = metrics.displacement_errors;
-
-    // Add trajectory point metrics if available
     if (i < trajectory_point_metrics_list_.size()) {
-      const auto & point_metrics = trajectory_point_metrics_list_[i];
-      traj["trajectory_point_metrics"]["lateral_accelerations"] =
-        point_metrics.lateral_accelerations;
-      traj["trajectory_point_metrics"]["longitudinal_jerks"] = point_metrics.longitudinal_jerks;
-      traj["trajectory_point_metrics"]["ttc_values"] = point_metrics.ttc_values;
-      traj["trajectory_point_metrics"]["lateral_deviations"] = point_metrics.lateral_deviations;
-      traj["trajectory_point_metrics"]["travel_distances"] = point_metrics.travel_distances;
+      const auto & pm = trajectory_point_metrics_list_[i];
+      traj["trajectory_point_metrics"]["lateral_accelerations"] = pm.lateral_accelerations;
+      traj["trajectory_point_metrics"]["longitudinal_jerks"] = pm.longitudinal_jerks;
+      traj["trajectory_point_metrics"]["ttc_values"] = pm.ttc_values;
+      traj["trajectory_point_metrics"]["lateral_deviations"] = pm.lateral_deviations;
+      traj["trajectory_point_metrics"]["travel_distances"] = pm.travel_distances;
     }
 
     trajectories.push_back(traj);
   }
-
   j["trajectories"] = trajectories;
 
   return j;
-}
-
-std::string OpenLoopEvaluator::format_horizon_key(double seconds) const
-{
-  std::ostringstream stream;
-  stream << std::fixed << std::setprecision(3) << seconds;
-  auto formatted = stream.str();
-  formatted.erase(formatted.find_last_not_of('0') + 1);
-  if (!formatted.empty() && formatted.back() == '.') {
-    formatted.pop_back();
-  }
-  if (formatted.empty()) {
-    formatted = "0";
-  }
-  return formatted + "s";
 }
 
 void OpenLoopEvaluator::save_dlr_style_result_to_bag(
@@ -902,29 +1037,14 @@ void OpenLoopEvaluator::save_dlr_style_result_to_bag(
     return;
   }
 
+  const bool has_frame = !metrics.horizon_results.empty();
   nlohmann::json result_json;
-  const auto & trajectory_points = trajectory_data->trajectory->points;
-  const size_t point_count =
-    std::min({trajectory_points.size(), metrics.ade.size(), metrics.displacement_errors.size()});
-  const bool has_frame = point_count > 0;
-
   result_json["Result"]["Success"] = has_frame;
-  result_json["Result"]["Summary"] =
-    has_frame ? "ADE/FDE metrics generated" : "ADE/FDE metrics unavailable";
+  result_json["Result"]["Summary"] = result_summary(has_frame, metrics.num_points);
   result_json["Stamp"]["System"] = trajectory_data->bag_timestamp.seconds();
   result_json["Stamp"]["ROS"] = trajectory_data->timestamp.seconds();
-
-  for (size_t index = 0; index < point_count; ++index) {
-    const auto horizon_sec =
-      rclcpp::Duration(trajectory_points.at(index).time_from_start).seconds();
-    const auto horizon_key = format_horizon_key(horizon_sec);
-    result_json["Frame"][horizon_key]["ADE"] = metrics.ade.at(index);
-    result_json["Frame"][horizon_key]["FDE"] = metrics.displacement_errors.at(index);
-  }
-
-  if (!result_json.contains("Frame")) {
-    result_json["Frame"] = nlohmann::json::object();
-  }
+  result_json["Frame"] = nlohmann::json::object();
+  fill_horizon_json(result_json["Frame"], metrics.horizon_results, metrics.num_points);
 
   std_msgs::msg::String result_msg;
   result_msg.data = result_json.dump();
@@ -986,19 +1106,14 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
     // Get and save evaluation results
     auto summary_json = get_summary_as_json();
     auto detailed_json = get_detailed_results_as_json();
+    auto full_json = get_full_results_as_json();
 
-    // Save using base class method
     save_json_results(
-      summary_json, bag_path, "open_loop", "time_step_based_trajectory_metric.json", false);
+      summary_json, bag_path, "open_loop", "time_step_based_trajectory_metric.json", false, false);
+    save_jsonl_results(detailed_json["results"], "time_step_based_trajectory_result.jsonl");
     save_json_results(
-      detailed_json, bag_path, "open_loop", "time_step_based_trajectory_result.jsonl", false);
-
-    // Log summary
-    RCLCPP_INFO(logger_, "Open-loop evaluation summary:");
-    if (summary_json.contains("ade") && summary_json["ade"].contains("mean")) {
-      RCLCPP_INFO(logger_, "  Mean ADE: %.3f m", static_cast<double>(summary_json["ade"]["mean"]));
-      RCLCPP_INFO(logger_, "  Mean FDE: %.3f m", static_cast<double>(summary_json["fde"]["mean"]));
-    }
+      full_json, bag_path, "open_loop", "time_step_based_trajectory_detailed_result.json", false,
+      true);
   }
 
   RCLCPP_INFO(logger_, "Open-loop evaluation complete");

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -25,6 +25,7 @@
 
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
@@ -96,7 +97,10 @@ public:
   }
 
   /**
-   * @brief Evaluate trajectories against ground truth localization data
+   * @brief Evaluate synchronized trajectories against ground-truth data.
+   *
+   * Computes per-trajectory open-loop metrics and optionally writes the resulting
+   * metric topics and result messages to an evaluation bag.
    * @param synchronized_data_list List of synchronized bag data containing trajectories and
    * localization
    * @param bag_writer Optional writer to save evaluation results to a new bag
@@ -114,13 +118,19 @@ public:
   nlohmann::json get_detailed_results_as_json() const override;
 
   /**
-   * @brief Get topic definitions for open-loop evaluation results
+   * @brief Return the result topics produced by the open-loop evaluator.
+   *
+   * Includes both raw metric topics and the DLR-format ADE/FDE result topic
+   * written to the evaluation bag.
    * @return Vector of topic name and type pairs
    */
   std::vector<std::pair<std::string, std::string>> get_result_topics() const override;
 
   /**
-   * @brief Run open-loop evaluation from bag file
+   * @brief Run open-loop evaluation directly from a rosbag.
+   *
+   * Reads the configured input topics from the bag, performs evaluation, and
+   * optionally writes the generated outputs to an evaluation bag.
    * @param bag_path Path to the bag file
    * @param evaluation_bag_writer Optional bag writer for results
    * @param topic_names Topic names configuration
@@ -131,8 +141,10 @@ public:
     const TopicNames & topic_names) override;
 
   /**
-   * @brief Structure to hold synchronized data with its precomputed ground truth trajectory
-   * (Public for use by ORSceneEvaluator)
+   * @brief Input bundle for evaluating one synchronized trajectory sample.
+   *
+   * Stores the synchronized input data together with the precomputed ground-truth
+   * trajectory used for metric calculation.
    */
   struct EvaluationData
   {
@@ -141,8 +153,10 @@ public:
   };
 
   /**
-   * @brief Generate ground truth trajectory for a single synchronized data point
-   * (Public for use by ORSceneEvaluator)
+   * @brief Generate the ground-truth trajectory for one synchronized trajectory sample.
+   *
+   * Uses the configured ground-truth source to create the reference trajectory
+   * aligned with the evaluated prediction trajectory.
    * @param trajectory_data Data containing the trajectory
    * @param all_data All synchronized data for interpolation
    * @return Ground truth trajectory or nullopt if generation failed
@@ -156,8 +170,9 @@ public:
     const std::shared_ptr<SynchronizedData> & trajectory_data) const;
 
   /**
-   * @brief Evaluate a single trajectory against ground truth
-   * (Public for use by ORSceneEvaluator)
+   * @brief Evaluate one trajectory against its ground-truth trajectory.
+   *
+   * Computes point-wise and aggregate metrics for a single synchronized sample.
    * @param eval_data Evaluation data containing trajectory and ground truth
    * @return Metrics for this trajectory
    */
@@ -165,7 +180,10 @@ public:
 
 private:
   /**
-   * @brief Prepare evaluation data with ground truth trajectories
+   * @brief Build the list of valid evaluation inputs for open-loop analysis.
+   *
+   * Generates ground-truth trajectories and excludes samples that cannot be
+   * evaluated with the configured ground-truth source.
    * @param synchronized_data_list List of synchronized data
    * @return Vector of evaluation data with ground truth (invalid data excluded)
    */
@@ -173,13 +191,13 @@ private:
     const std::vector<std::shared_ptr<SynchronizedData>> & synchronized_data_list);
 
   /**
-   * @brief Calculate 2D Euclidean distance between two points
+   * @brief Compute planar Euclidean distance between two positions.
    */
   double calculate_distance_2d(
     const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2);
 
   /**
-   * @brief Calculate errors in vehicle coordinate frame
+   * @brief Compute longitudinal and lateral position errors in the vehicle frame.
    * @param trajectory_pose Trajectory pose (position and orientation)
    * @param ground_truth_pose Ground truth pose (position and orientation)
    * @return Pair of (longitudinal_error, lateral_error) in vehicle frame
@@ -189,7 +207,10 @@ private:
     const geometry_msgs::msg::Pose & ground_truth_pose);
 
   /**
-   * @brief Find ground truth data at a specific time using interpolation
+   * @brief Interpolate ground-truth pose at a requested timestamp.
+   *
+   * Searches neighboring synchronized ground-truth samples and interpolates a
+   * pose when the requested time lies within the available range.
    * @param target_time Time to interpolate ground truth
    * @param ground_truth_data List of ground truth data points
    * @return Interpolated pose or nullptr if interpolation not possible
@@ -203,14 +224,33 @@ private:
     const autoware_planning_msgs::msg::Trajectory & gt_trajectory) const;
 
   /**
-   * @brief Save evaluation metrics to bag
+   * @brief Write per-trajectory evaluation outputs to the result bag.
+   *
+   * Saves raw metric arrays, writes the DLR-format ADE/FDE result message, and
+   * stores the compared ground-truth trajectory for the evaluated sample.
    */
   void save_metrics_to_bag(
     const OpenLoopTrajectoryMetrics & metrics, const EvaluationData & eval_data,
     rosbag2_cpp::Writer & bag_writer);
 
   /**
-   * @brief Calculate summary statistics from all evaluations
+   * @brief Write ADE/FDE results in the driving_log_replayer result format.
+   *
+   * Serializes the metrics into a JSON payload with top-level Result, Stamp,
+   * and Frame fields and writes it to
+   * /driving_log_replayer/time_step_based_trajectory/results as std_msgs/msg/String.
+   */
+  void save_dlr_style_result_to_bag(
+    const OpenLoopTrajectoryMetrics & metrics, const EvaluationData & eval_data,
+    rosbag2_cpp::Writer & bag_writer);
+
+  std::string format_horizon_key(double seconds) const;
+
+  /**
+   * @brief Aggregate summary statistics across all evaluated trajectories.
+   *
+   * Computes dataset-level ADE, FDE, lateral-deviation, coverage, and duration
+   * statistics from the collected per-trajectory metrics.
    */
   void calculate_summary();
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -35,6 +35,17 @@
 namespace autoware::planning_data_analyzer
 {
 
+struct HorizonMetrics
+{
+  double ade;
+  double fde;
+  double average_lateral_deviation;
+  double max_lateral_deviation;
+  double average_longitudinal_deviation;
+  double max_longitudinal_deviation;
+  double min_ttc;
+};
+
 struct OpenLoopTrajectoryMetrics
 {
   // Point-wise metrics
@@ -46,6 +57,9 @@ struct OpenLoopTrajectoryMetrics
   std::vector<double> ade;                  // Average Displacement Error at each trajectory point
   std::vector<double> ttc;                  // Time To Collision at each trajectory point
 
+  // Per-horizon metrics in insertion order: "full" first, then "1s", "2s", ...
+  std::vector<std::pair<std::string, HorizonMetrics>> horizon_results;
+
   // Ground truth trajectory for this evaluation
   std::vector<geometry_msgs::msg::Pose> ground_truth_poses;  // Interpolated ground truth poses
 
@@ -53,7 +67,8 @@ struct OpenLoopTrajectoryMetrics
   size_t num_points;           // Number of trajectory points
   double trajectory_duration;  // Total trajectory duration in seconds
 
-  rclcpp::Time trajectory_timestamp;   // When the trajectory was published
+  rclcpp::Time trajectory_timestamp;   // When the trajectory was published (ROS time)
+  rclcpp::Time bag_timestamp;          // Corresponding bag/system timestamp
   rclcpp::Time evaluation_start_time;  // Start time of evaluation window
   rclcpp::Time evaluation_end_time;    // End time of evaluation window
 };
@@ -115,9 +130,20 @@ public:
 
   void set_metric_variant(const std::string & metric_variant) { metric_variant_ = metric_variant; }
 
+  void set_evaluation_horizons(const std::vector<double> & horizons)
+  {
+    evaluation_horizons_ = horizons;
+  }
+
   nlohmann::json get_summary_as_json() const override;
 
   nlohmann::json get_detailed_results_as_json() const override;
+
+  /**
+   * @brief Full results JSON: summary + per-trajectory per-point data + evaluation_info when saved.
+   * For machine consumption / debugging; not human-readable at scale.
+   */
+  nlohmann::json get_full_results_as_json() const;
 
   /**
    * @brief Return the result topics produced by the open-loop evaluator.
@@ -255,8 +281,6 @@ private:
   std::string compared_trajectory_topic() const;
   std::string dlr_result_topic() const;
 
-  std::string format_horizon_key(double seconds) const;
-
   /**
    * @brief Aggregate summary statistics across all evaluated trajectories.
    *
@@ -271,6 +295,7 @@ private:
   std::string metric_variant_;
   GTSourceMode gt_source_mode_;
   double gt_sync_tolerance_ms_;
+  std::vector<double> evaluation_horizons_;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -113,6 +113,8 @@ public:
 
   std::vector<OpenLoopTrajectoryMetrics> get_metrics() const { return metrics_list_; }
 
+  void set_metric_variant(const std::string & metric_variant) { metric_variant_ = metric_variant; }
+
   nlohmann::json get_summary_as_json() const override;
 
   nlohmann::json get_detailed_results_as_json() const override;
@@ -244,6 +246,15 @@ private:
     const OpenLoopTrajectoryMetrics & metrics, const EvaluationData & eval_data,
     rosbag2_cpp::Writer & bag_writer);
 
+  void save_trajectory_point_metrics_to_bag_with_variant(
+    const metrics::TrajectoryPointMetrics & metrics, rosbag2_cpp::Writer & bag_writer,
+    const rclcpp::Time & normalized_timestamp) const;
+
+  std::string metric_topic(const std::string & metric_name) const;
+  std::string trajectory_metric_topic(const std::string & metric_name) const;
+  std::string compared_trajectory_topic() const;
+  std::string dlr_result_topic() const;
+
   std::string format_horizon_key(double seconds) const;
 
   /**
@@ -257,6 +268,7 @@ private:
   std::vector<OpenLoopTrajectoryMetrics> metrics_list_;
   std::vector<metrics::TrajectoryPointMetrics> trajectory_point_metrics_list_;
   OpenLoopEvaluationSummary summary_;
+  std::string metric_variant_;
   GTSourceMode gt_source_mode_;
   double gt_sync_tolerance_ms_;
 };

--- a/planning/autoware_planning_data_analyzer/src/or_scene_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/or_scene_evaluator.cpp
@@ -192,8 +192,12 @@ std::pair<rclcpp::Time, rclcpp::Time> ORSceneEvaluator::run_evaluation_from_bag(
   calculate_summary();
 
   // Save results
+  auto summary_json = get_summary_as_json();
   auto detailed_json = get_detailed_results_as_json();
-  save_json_results(detailed_json, bag_path, "or_scene", "or_scene_evaluation_results");
+  save_json_results(
+    summary_json, bag_path, "or_scene", "time_step_based_trajectory_metric.json", false);
+  save_json_results(
+    detailed_json, bag_path, "or_scene", "time_step_based_trajectory_result.jsonl", false);
 
   // Log summary
   RCLCPP_INFO(logger_, "OR scene evaluation complete:");

--- a/planning/autoware_planning_data_analyzer/src/serialized_bag_message.hpp
+++ b/planning/autoware_planning_data_analyzer/src/serialized_bag_message.hpp
@@ -1,0 +1,39 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SERIALIZED_BAG_MESSAGE_HPP_
+#define SERIALIZED_BAG_MESSAGE_HPP_
+
+#include <rosbag2_storage/serialized_bag_message.hpp>
+
+#include <cstdint>
+
+namespace autoware::planning_data_analyzer
+{
+
+#ifdef ROS_DISTRO_HUMBLE
+inline uint64_t get_timestamp_ns(const rosbag2_storage::SerializedBagMessage & bag_message)
+{
+  return bag_message.time_stamp;
+}
+#else
+inline uint64_t get_timestamp_ns(const rosbag2_storage::SerializedBagMessage & bag_message)
+{
+  return bag_message.recv_timestamp;
+}
+#endif
+
+}  // namespace autoware::planning_data_analyzer
+
+#endif  // SERIALIZED_BAG_MESSAGE_HPP_

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -132,19 +132,6 @@ TEST_F(OpenLoopGTSourceModeTest, GTTrajectoryModeUsesSyncToleranceForBoundaryInt
   EXPECT_EQ(tolerant_evaluator.get_metrics().size(), 1u);
 }
 
-TEST_F(OpenLoopGTSourceModeTest, FormatsDLRHorizonKeysAsExpected)
-{
-  OpenLoopEvaluator evaluator(
-    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
-    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
-
-  EXPECT_EQ(evaluator.format_horizon_key(0.0), "0s");
-  EXPECT_EQ(evaluator.format_horizon_key(0.058), "0.058s");
-  EXPECT_EQ(evaluator.format_horizon_key(0.1), "0.1s");
-  EXPECT_EQ(evaluator.format_horizon_key(1.23), "1.23s");
-  EXPECT_EQ(evaluator.format_horizon_key(2.9999), "3s");
-}
-
 TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)
 {
   OpenLoopEvaluator evaluator(

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -20,7 +20,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
+#include <string>
 #include <vector>
 
 using autoware::planning_data_analyzer::OpenLoopEvaluator;
@@ -141,4 +143,33 @@ TEST_F(OpenLoopGTSourceModeTest, FormatsDLRHorizonKeysAsExpected)
   EXPECT_EQ(evaluator.format_horizon_key(0.1), "0.1s");
   EXPECT_EQ(evaluator.format_horizon_key(1.23), "1.23s");
   EXPECT_EQ(evaluator.format_horizon_key(2.9999), "3s");
+}
+
+TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)
+{
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+
+  evaluator.set_metric_variant("raw");
+
+  EXPECT_EQ(evaluator.metric_topic("ade"), "/open_loop/metrics/raw/ade");
+  EXPECT_EQ(
+    evaluator.trajectory_metric_topic("lateral_accelerations"),
+    "/trajectory/raw/lateral_accelerations");
+  EXPECT_EQ(evaluator.compared_trajectory_topic(), "/evaluation/compared_trajectory/raw");
+  EXPECT_EQ(
+    evaluator.dlr_result_topic(), "/driving_log_replayer/time_step_based_trajectory/raw/results");
+
+  const auto topics = evaluator.get_result_topics();
+  const auto has_topic = [&topics](const std::string & topic_name) {
+    return std::any_of(topics.begin(), topics.end(), [&topic_name](const auto & topic) {
+      return topic.first == topic_name;
+    });
+  };
+
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/ade"));
+  EXPECT_TRUE(has_topic("/trajectory/raw/lateral_accelerations"));
+  EXPECT_TRUE(has_topic("/evaluation/compared_trajectory/raw"));
+  EXPECT_TRUE(has_topic("/driving_log_replayer/time_step_based_trajectory/raw/results"));
 }

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <sstream>
+
+#define private public
 #include "../src/open_loop_evaluator.hpp"
+#undef private
 
 #include <gtest/gtest.h>
 
@@ -124,4 +128,17 @@ TEST_F(OpenLoopGTSourceModeTest, GTTrajectoryModeUsesSyncToleranceForBoundaryInt
     OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 120.0);
   EXPECT_NO_THROW(tolerant_evaluator.evaluate(sync_data_list, nullptr));
   EXPECT_EQ(tolerant_evaluator.get_metrics().size(), 1u);
+}
+
+TEST_F(OpenLoopGTSourceModeTest, FormatsDLRHorizonKeysAsExpected)
+{
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+
+  EXPECT_EQ(evaluator.format_horizon_key(0.0), "0s");
+  EXPECT_EQ(evaluator.format_horizon_key(0.058), "0.058s");
+  EXPECT_EQ(evaluator.format_horizon_key(0.1), "0.1s");
+  EXPECT_EQ(evaluator.format_horizon_key(1.23), "1.23s");
+  EXPECT_EQ(evaluator.format_horizon_key(2.9999), "3s");
 }

--- a/planning/planning_debug_tools/README.md
+++ b/planning/planning_debug_tools/README.md
@@ -202,6 +202,8 @@ The following topics are loaded from the rosbag and replayed:
 - `/perception/object_recognition/objects` (autoware_perception_msgs/msg/PredictedObjects): Predicted objects (default)
 - `/perception/traffic_light_recognition/traffic_signals` (autoware_perception_msgs/msg/TrafficLightGroupArray): Traffic light signals
 - `/perception/occupancy_grid_map/map` (nav_msgs/msg/OccupancyGrid): Occupancy grid map (with transient_local QoS)
+- `/planning/mission_planning/route` (autoware_planning_msgs/msg/LaneletRoute): Route data (with transient_local QoS, when `--replay-route` option is used)
+- `/planning/mission_planning/state` (autoware_planning_msgs/msg/RouteState): Route state data (with transient_local QoS, when `--replay-route` option is used)
 - `<any CompressedImage topic>` (sensor_msgs/msg/CompressedImage): Reference images for visualization (when `--reference-image-topics` is used)
 
 ### Published Topics
@@ -211,6 +213,8 @@ The following topics are published during replay:
 - `/perception/object_recognition/tracking/objects` or `/perception/object_recognition/objects`: Replayed perception objects
 - `/perception/traffic_light_recognition/traffic_signals`: Replayed traffic light signals
 - `/perception/occupancy_grid_map/map`: Replayed occupancy grid map (published with transient_local QoS, so late subscribers can receive the latest map)
+- `/planning/mission_planning/route`: Replayed route (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
+- `/planning/mission_planning/state`: Replayed route state (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
 - `<any CompressedImage topic>`: Replayed reference images (published to the same topic name as in the rosbag)
 - `/perception_reproducer/rosbag_ego_odom`: Debug topic for recorded ego odometry
 - `/initialpose`: Initial pose (when `-p` option is used)
@@ -234,6 +238,7 @@ This design results in the following behavior:
 - `-r`, `--search-radius`: Set the search radius in meters (default: 1.5m). If set to 0, always publishes the nearest message
 - `-c`, `--reproduce-cool-down`: Set the cool down time in seconds (default: 80.0s)
 - `-p`, `--pub-route`: Initialize localization and publish a route based on poses from the rosbag
+- `--replay-route`: Replay route and route state topics from rosbag data with transient_local QoS (only publishes when the message changes)
 - `-n`, `--noise`: Apply perception noise to objects when publishing repeated messages (default: False)
 - `-f`, `--rosbag-format`: Specify rosbag data format (default: "db3")
 - `--reference-image-topics`: Comma-separated list of CompressedImage topics to load and publish (e.g., `"/sensing/camera/camera0/image_raw/compressed,/sensing/camera/camera1/image_raw/compressed"`)
@@ -271,6 +276,14 @@ Example usage with route publication:
 ros2 run planning_debug_tools perception_reproducer -b <bag-file> -p
 ```
 
+The `--replay-route` option enables replaying of route and route state topics directly from the rosbag data. These topics use transient_local QoS and are only published when the message content changes (avoiding redundant publishes). This is useful when you want to replay the exact route that was recorded in the rosbag.
+
+Example usage with route replaying:
+
+```bash
+ros2 run planning_debug_tools perception_reproducer -b <bag-file> --replay-route
+```
+
 ## Perception replayer
 
 A part of the feature is under development.
@@ -290,6 +303,8 @@ The following topics are loaded from the rosbag and replayed:
 - `/perception/object_recognition/objects` (autoware_perception_msgs/msg/PredictedObjects): Predicted objects (default)
 - `/perception/traffic_light_recognition/traffic_signals` (autoware_perception_msgs/msg/TrafficLightGroupArray): Traffic light signals
 - `/perception/occupancy_grid_map/map` (nav_msgs/msg/OccupancyGrid): Occupancy grid map (with transient_local QoS)
+- `/planning/mission_planning/route` (autoware_planning_msgs/msg/LaneletRoute): Route data (with transient_local QoS, when `--replay-route` option is used)
+- `/planning/mission_planning/state` (autoware_planning_msgs/msg/RouteState): Route state data (with transient_local QoS, when `--replay-route` option is used)
 - `<any CompressedImage topic>` (sensor_msgs/msg/CompressedImage): Reference images for visualization
 
 ### Published Topics
@@ -299,6 +314,8 @@ The following topics are published during replay:
 - `/perception/object_recognition/tracking/objects` or `/perception/object_recognition/objects`: Replayed perception objects
 - `/perception/traffic_light_recognition/traffic_signals`: Replayed traffic light signals
 - `/perception/occupancy_grid_map/map`: Replayed occupancy grid map (published with transient_local QoS, so late subscribers can receive the latest map)
+- `/planning/mission_planning/route`: Replayed route (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
+- `/planning/mission_planning/state`: Replayed route state (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
 - `<any CompressedImage topic>`: Replayed reference images
 - `/perception_reproducer/rosbag_ego_odom`: Debug topic for recorded ego odometry
 
@@ -306,6 +323,7 @@ The following topics are published during replay:
 
 - `-b`, `--bag`: Rosbag file path (required)
 - `-t`, `--tracked-object`: Publish tracked objects
+- `--replay-route`: Replay route and route state topics from rosbag data with transient_local QoS (only publishes when the message changes)
 - `-f`, `--rosbag-format`: Specify rosbag data format (default: "db3")
 - `-v`, `--verbose`: Output debug data
 - `-h`, `--help`: Show help message

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -14,6 +14,7 @@
 
 #include "perception_replayer_common.hpp"
 
+#include "serialized_bag_message.hpp"
 #include "utils.hpp"
 
 #include <rosbag2_cpp/reader.hpp>
@@ -136,13 +137,13 @@ void PerceptionReplayerCommon::load_rosbag(
         if (bag_message->topic_name == ego_odom_topic) {
           const auto ego_odom_msg =
             utils::deserialize_message<Odometry>(bag_message->serialized_data);
-          const rclcpp::Time timestamp(bag_message->time_stamp);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
           rosbag_ego_odom_data_.emplace_back(timestamp, *ego_odom_msg);
         }
 
         // deserialize objects messages
         if (bag_message->topic_name == objects_topic) {
-          const rclcpp::Time timestamp(bag_message->time_stamp);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
           if (param_.tracked_object) {
             const auto objects_msg =
               utils::deserialize_message<TrackedObjects>(bag_message->serialized_data);
@@ -158,7 +159,7 @@ void PerceptionReplayerCommon::load_rosbag(
         if (bag_message->topic_name == traffic_signals_topic) {
           const auto traffic_signals_msg =
             utils::deserialize_message<TrafficLightGroupArray>(bag_message->serialized_data);
-          const rclcpp::Time timestamp(bag_message->time_stamp);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
           rosbag_traffic_signals_data_.emplace_back(timestamp, *traffic_signals_msg);
         }
 
@@ -166,7 +167,7 @@ void PerceptionReplayerCommon::load_rosbag(
         if (bag_message->topic_name == occupancy_grid_topic) {
           const auto occupancy_grid_msg =
             utils::deserialize_message<OccupancyGrid>(bag_message->serialized_data);
-          const rclcpp::Time timestamp(bag_message->time_stamp);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
           rosbag_occupancy_grid_data_.emplace_back(timestamp, *occupancy_grid_msg);
         }
 
@@ -175,7 +176,7 @@ void PerceptionReplayerCommon::load_rosbag(
           if (bag_message->topic_name == ref_topic) {
             const auto image_msg =
               utils::deserialize_message<CompressedImage>(bag_message->serialized_data);
-            const rclcpp::Time timestamp(bag_message->time_stamp);
+            const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
             rosbag_reference_image_data_[ref_topic].emplace_back(timestamp, *image_msg);
             break;  // Found matching topic, no need to check others
           }

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -108,6 +108,8 @@ void PerceptionReplayerCommon::load_rosbag(
   const std::string ego_odom_topic = "/localization/kinematic_state";
   const std::string traffic_signals_topic = "/perception/traffic_light_recognition/traffic_signals";
   const std::string occupancy_grid_topic = "/perception/occupancy_grid_map/map";
+  const std::string route_topic = "/planning/mission_planning/route";
+  const std::string route_state_topic = "/planning/mission_planning/state";
 
   // create topic filter
   rosbag2_storage::StorageFilter storage_filter;
@@ -117,6 +119,11 @@ void PerceptionReplayerCommon::load_rosbag(
     traffic_signals_topic,
     occupancy_grid_topic,
   };
+
+  if (param_.replay_route) {
+    storage_filter.topics.push_back(route_topic);
+    storage_filter.topics.push_back(route_state_topic);
+  }
 
   // Add reference image topics to filter
   for (const auto & topic : param_.reference_image_topics) {
@@ -169,6 +176,22 @@ void PerceptionReplayerCommon::load_rosbag(
             utils::deserialize_message<OccupancyGrid>(bag_message->serialized_data);
           const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
           rosbag_occupancy_grid_data_.emplace_back(timestamp, *occupancy_grid_msg);
+        }
+
+        // deserialize route messages
+        if (bag_message->topic_name == route_topic) {
+          const auto route_msg =
+            utils::deserialize_message<LaneletRoute>(bag_message->serialized_data);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
+          rosbag_route_data_.emplace_back(timestamp, *route_msg);
+        }
+
+        // deserialize route_state messages
+        if (bag_message->topic_name == route_state_topic) {
+          const auto route_state_msg =
+            utils::deserialize_message<RouteState>(bag_message->serialized_data);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
+          rosbag_route_state_data_.emplace_back(timestamp, *route_state_msg);
         }
 
         // deserialize reference image messages
@@ -254,6 +277,15 @@ PerceptionReplayerCommon::PerceptionReplayerCommon(
   occupancy_grid_pub_ =
     this->create_publisher<OccupancyGrid>("/perception/occupancy_grid_map/map", occupancy_grid_qos);
 
+  if (param_.replay_route) {
+    rclcpp::QoS transient_local_qos(1);
+    transient_local_qos.transient_local();
+    route_pub_ =
+      this->create_publisher<LaneletRoute>("/planning/mission_planning/route", transient_local_qos);
+    route_state_pub_ =
+      this->create_publisher<RouteState>("/planning/mission_planning/state", transient_local_qos);
+  }
+
   recorded_ego_as_initialpose_pub_ =
     this->create_publisher<PoseWithCovarianceStamped>("/initialpose", 1);
   goal_as_mission_planning_goal_pub_ =
@@ -323,6 +355,10 @@ void PerceptionReplayerCommon::publish_topics_at_timestamp(
     msg.header.stamp = current_timestamp;
     occupancy_grid_pub_->publish(msg);
   }
+
+  if (param_.replay_route) {
+    publish_route_at_timestamp(bag_timestamp);
+  }
 }
 
 void PerceptionReplayerCommon::publish_traffic_lights_at_timestamp(
@@ -370,6 +406,47 @@ void PerceptionReplayerCommon::publish_reference_images_at_timestamp(
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), 5000, "No reference image found for topic %s at timestamp %f",
         topic.c_str(), bag_timestamp.seconds());
+    }
+  }
+}
+
+void PerceptionReplayerCommon::publish_route_at_timestamp(const rclcpp::Time & bag_timestamp)
+{
+  // Helper: find the index of the last message at or before bag_timestamp.
+  // Returns nullopt if there is no such message.
+  auto find_last_before = [](const auto & data, const rclcpp::Time & ts) -> std::optional<size_t> {
+    if (data.empty() || data.front().first > ts) {
+      return std::nullopt;
+    }
+    // binary search for rightmost element with timestamp <= ts
+    size_t lo = 0;
+    size_t hi = data.size();
+    while (lo < hi) {
+      const size_t mid = lo + (hi - lo) / 2;
+      if (data[mid].first <= ts) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo - 1;
+  };
+
+  // route
+  if (!rosbag_route_data_.empty()) {
+    const auto idx = find_last_before(rosbag_route_data_, bag_timestamp);
+    if (idx.has_value() && last_published_route_idx_ != idx.value()) {
+      route_pub_->publish(rosbag_route_data_[idx.value()].second);
+      last_published_route_idx_ = idx.value();
+    }
+  }
+
+  // route state
+  if (!rosbag_route_state_data_.empty()) {
+    const auto idx = find_last_before(rosbag_route_state_data_, bag_timestamp);
+    if (idx.has_value() && last_published_route_state_idx_ != idx.value()) {
+      route_state_pub_->publish(rosbag_route_state_data_[idx.value()].second);
+      last_published_route_state_idx_ = idx.value();
     }
   }
 }

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
@@ -42,6 +42,7 @@ struct PerceptionReplayerCommonParam
   std::string rosbag_path;
   std::string rosbag_format;
   bool tracked_object;
+  bool replay_route;
   std::vector<std::string> reference_image_topics;  // Topics for reference images
 };
 
@@ -118,6 +119,13 @@ public:
   void publish_reference_images_at_timestamp(
     const rclcpp::Time & bag_timestamp, const rclcpp::Time & current_timestamp);
 
+  /**
+   * @brief Publish route and route state (transient_local) at the given timestamp.
+   * Only publishes when the message to publish differs from the last published one.
+   * @param bag_timestamp
+   */
+  void publish_route_at_timestamp(const rclcpp::Time & bag_timestamp);
+
 protected:
   const PerceptionReplayerCommonParam param_;
 
@@ -187,6 +195,8 @@ protected:
   std::vector<utils::DataStamped<TrackedObjects>> rosbag_tracked_objects_data_;
   std::vector<utils::DataStamped<TrafficLightGroupArray>> rosbag_traffic_signals_data_;
   std::vector<utils::DataStamped<OccupancyGrid>> rosbag_occupancy_grid_data_;
+  std::vector<utils::DataStamped<LaneletRoute>> rosbag_route_data_;
+  std::vector<utils::DataStamped<RouteState>> rosbag_route_state_data_;
 
   // Reference image data: topic name -> timestamped messages
   std::unordered_map<std::string, std::vector<utils::DataStamped<CompressedImage>>>
@@ -215,6 +225,12 @@ protected:
   rclcpp::PublisherBase::SharedPtr objects_pub_;
   rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr traffic_signals_pub_;
   rclcpp::Publisher<OccupancyGrid>::SharedPtr occupancy_grid_pub_;
+  rclcpp::Publisher<LaneletRoute>::SharedPtr route_pub_;
+  rclcpp::Publisher<RouteState>::SharedPtr route_state_pub_;
+
+  // track last published index to avoid redundant publishes for transient_local topics
+  std::optional<size_t> last_published_route_idx_;
+  std::optional<size_t> last_published_route_state_idx_;
 
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr recorded_ego_as_initialpose_pub_;
   rclcpp::Publisher<PoseStamped>::SharedPtr goal_as_mission_planning_goal_pub_;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_node.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_node.cpp
@@ -77,6 +77,12 @@ int main(int argc, char * argv[])
       "rosbag data format", "{sqlite3,mcap}", "sqlite3");
     options << rosbag_format_option;
 
+    QCommandLineOption replay_route_option(
+      QStringList() << "replay-route",
+      "replay route and route state topics from rosbag data with transient_local QoS. "
+      "Only publishes when the message changes (i.e., not redundantly).");
+    options << replay_route_option;
+
     for (const auto & option : options) {
       parser.addOption(option);
     }
@@ -109,6 +115,7 @@ int main(int argc, char * argv[])
     }
 
     perception_replayer_param.tracked_object = parser.isSet(tracked_object_option);
+    perception_replayer_param.replay_route = parser.isSet(replay_route_option);
 
     rclcpp::NodeOptions node_options;
     auto node = std::make_shared<PerceptionReplayer>(perception_replayer_param, node_options);

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer_node.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer_node.cpp
@@ -99,6 +99,12 @@ int main(int argc, char ** argv)
       "end of the rosbag. By default, route are not published.");
     options << pub_route_option;
 
+    const QCommandLineOption replay_route_option(
+      QStringList() << "replay-route",
+      "replay route and route state topics from rosbag data with transient_local QoS. "
+      "Only publishes when the message changes (i.e., not redundantly).");
+    options << replay_route_option;
+
     const QCommandLineOption verbose_option(
       QStringList() << "v"
                     << "verbose",
@@ -141,6 +147,7 @@ int main(int argc, char ** argv)
     param.noise = parser.isSet(noise_option);
     param.verbose = parser.isSet(verbose_option);
     param.publish_route = parser.isSet(pub_route_option);
+    param.replay_route = parser.isSet(replay_route_option);
 
     // Parse comma-separated reference image topics
     const QString topics_str = parser.value(ref_image_topics_option);

--- a/planning/planning_debug_tools/src/perception_replayer/serialized_bag_message.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/serialized_bag_message.hpp
@@ -1,0 +1,39 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PERCEPTION_REPLAYER__SERIALIZED_BAG_MESSAGE_HPP_
+#define PERCEPTION_REPLAYER__SERIALIZED_BAG_MESSAGE_HPP_
+
+#include <rosbag2_storage/serialized_bag_message.hpp>
+
+#include <cstdint>
+
+namespace autoware::planning_debug_tools
+{
+
+#ifdef ROS_DISTRO_HUMBLE
+uint64_t get_timestamp_ns(const rosbag2_storage::SerializedBagMessage & bag_message)
+{
+  return bag_message.time_stamp;
+}
+#else
+uint64_t get_timestamp_ns(const rosbag2_storage::SerializedBagMessage & bag_message)
+{
+  return bag_message.recv_timestamp;
+}
+#endif
+
+}  // namespace autoware::planning_debug_tools
+
+#endif  // PERCEPTION_REPLAYER__SERIALIZED_BAG_MESSAGE_HPP_

--- a/planning/planning_debug_tools/src/perception_replayer/type_alias.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/type_alias.hpp
@@ -18,6 +18,8 @@
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
@@ -32,6 +34,8 @@ using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::TrackedObjects;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::RouteState;
 using geometry_msgs::msg::PoseStamped;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 using nav_msgs::msg::OccupancyGrid;


### PR DESCRIPTION
## Description

Cherry-pick PRs of planning_data_analyzer and perception_reproducer for DLR tests, especially `perception reproducer` tests and `time_step_based_trajectory` tests.

**planning_data_analyzer**:
- Updated maintainers
  - https://github.com/autowarefoundation/autoware_tools/pull/319
  - https://github.com/autowarefoundation/autoware_tools/pull/356
- Refactor code and output format of JSON files and rosbag for the DLR / Lichtblick needs.
  - https://github.com/autowarefoundation/autoware_tools/pull/366
  - https://github.com/autowarefoundation/autoware_tools/pull/367
  - https://github.com/autowarefoundation/autoware_tools/pull/368
  - https://github.com/autowarefoundation/autoware_tools/pull/371
  - https://github.com/autowarefoundation/autoware_tools/pull/372

**perception reproducer**
- Publish route directly from the rosbag
  - https://github.com/autowarefoundation/autoware_tools/pull/369

**Other**
- https://github.com/autowarefoundation/autoware_tools/pull/347

## How was this PR tested?

[Evaluator](https://evaluation.tier4.jp/evaluation/reports/ac0e007a-f0fc-5afa-a25c-c8d41b9ca141?project_id=x2_dev)

## Notes for reviewers

This PR is tested with this [PR to update configs](https://github.com/tier4/pilot-auto.x2/pull/3389)

## Effects on system behavior

None.
