### PR TITLE
fix(planning_data_analyzer): preserve valid message stamps for gt_trajectory evaluation

### DIFF
--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -287,7 +287,7 @@ typename std::enable_if<has_header_stamp<MessageType>::value, void>::type
 set_header_timestamp_if_needed(
   MessageType & msg, bool use_bag_timestamp, const rclcpp::Time & bag_time)
 {
-  if (use_bag_timestamp && msg.header.stamp != rclcpp::Time(0)) {
+  if (use_bag_timestamp && msg.header.stamp == rclcpp::Time(0)) {
     msg.header.stamp = bag_time;
   }
 }

--- a/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
@@ -82,3 +82,25 @@ TEST_F(BagHandlerTest, GetLatestBeforeOrEqual)
   EXPECT_EQ(
     buffer.get_latest_before_or_equal(rclcpp::Time(10, 0).nanoseconds())->header.stamp.sec, 3);
 }
+
+TEST_F(BagHandlerTest, SetHeaderTimestampIfNeededPreservesValidStamp)
+{
+  nav_msgs::msg::Odometry msg;
+  msg.header.stamp = rclcpp::Time(100, 0);
+
+  autoware::planning_data_analyzer::set_header_timestamp_if_needed(
+    msg, true, rclcpp::Time(200, 0));
+
+  EXPECT_EQ(rclcpp::Time(msg.header.stamp).nanoseconds(), rclcpp::Time(100, 0).nanoseconds());
+}
+
+TEST_F(BagHandlerTest, SetHeaderTimestampIfNeededFillsZeroStampFromBagTime)
+{
+  nav_msgs::msg::Odometry msg;
+  msg.header.stamp = rclcpp::Time(0, 0);
+
+  autoware::planning_data_analyzer::set_header_timestamp_if_needed(
+    msg, true, rclcpp::Time(200, 0));
+
+  EXPECT_EQ(rclcpp::Time(msg.header.stamp).nanoseconds(), rclcpp::Time(200, 0).nanoseconds());
+}


### PR DESCRIPTION
# Description
This PR fixes abnormal large ADE/FDE in open-loop `gt_trajectory` evaluation on `beta/v0.48` by preserving valid message header stamps during bag processing.

Included in this PR:

preservation of valid `header.stamp` values during bag processing
fallback to bag timestamp only when the original message stamp is zero
regression tests for both stamp-preservation and zero-stamp fallback behavior

The evaluation path keeps the existing analyzer behavior and changes only the timestamp fallback condition used when reading bag messages.

# How was this PR tested?
ran the analyzer on the issued [Odaiba bag](https://star4.slack.com/archives/C09J2QMQZ1B/p1776073375352749?thread_ts=1776053006.201029&cid=C09J2QMQZ1B) and compared the output before and after the change.

Validation results from the reproduced bag:

Before:
- `1.0s/ade/max = 8.7426m`
- `1.0s/fde/max = 8.8243m`

After:
- `1.0s/ade/max = 1.8037m`
- `1.0s/fde/max = 3.7630m`

Additional validation:

package-scoped tests passed:

# Notes for reviewers
- This is intended as a minimal hotfix for the `beta/v0.48` line used by `pilot-auto.x2`.
