### PR TITLE
fix(planning_debug_tools): migrate to rclcpp typesupport helpers (#403)

### DIFF
--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -17,9 +17,9 @@
 #include "serialized_bag_message.hpp"
 #include "utils.hpp"
 
+#include <rclcpp/typesupport_helpers.hpp>
 #include <rosbag2_cpp/reader.hpp>
 #include <rosbag2_cpp/readers/sequential_reader.hpp>
-#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <rosbag2_storage/storage_filter.hpp>
 #include <rosbag2_storage/storage_options.hpp>
 
@@ -79,12 +79,16 @@ void PerceptionReplayerCommon::load_rosbag(
   // try to load type support for each topic
   for (const auto & topic_meta : topics) {
     try {
-      auto library =
-        rosbag2_cpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
+      auto library = rclcpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
       type_support_libs[topic_meta.name] = library;
 
+#ifdef ROS_DISTRO_HUMBLE
       const rosidl_message_type_support_t * type_support =
-        rosbag2_cpp::get_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", library);
+        rclcpp::get_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", *library);
+#else
+      const rosidl_message_type_support_t * type_support =
+        rclcpp::get_message_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", *library);
+#endif
 
       if (type_support) {
         type_support_map[topic_meta.name] = std::shared_ptr<const rosidl_message_type_support_t>(


### PR DESCRIPTION
## Description

> [!NOTE]
> **Jazzy migration**

* cherry-pick https://github.com/autowarefoundation/autoware_tools/pull/403

### Original Description
> * Replace the deprecated rosbag2_cpp::get_typesupport_library and rosbag2_cpp::get_typesupport_handle calls in [planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp](https://github.com/autowarefoundation/autoware_tools/blob/6106a5c361240fe3abfd0d47a99fa5e46ec7b135/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp) with their rclcpp counterparts.
> * Swap the include from <rosbag2_cpp/typesupport_helpers.hpp> to <rclcpp/typesupport_helpers.hpp>; dereference the shared_ptr<rcpputils::SharedLibrary> since the rclcpp variants take a reference, not a shared_ptr.
> * Gate the handle call on ROS_DISTRO_HUMBLE (a compile definition set by autoware_package()), because the function was renamed between distros.


### Related Jazzy migration PRs 

- https://github.com/tier4/autoware_tools/pull/50
- https://github.com/tier4/autoware_universe/pull/2930
- https://github.com/tier4/autoware_universe/pull/2929
- https://github.com/tier4/autoware_universe/pull/2928

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
