### PR TITLE
fix(build_depends):  fix version for core, universe, and lanelet2_extension

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -13,7 +13,7 @@ repositories:
   core/autoware_core:
     type: git
     url: https://github.com/tier4/autoware_core.git
-    version: beta/v0.64
+    version: e576dfcd3f738a6c4d973edcbb51041865394893
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -29,7 +29,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.12.0
+    version: 38b5af5ac8121989e018ef6e48a1d508119e0128
   # universe
   universe/autoware_universe:
     type: git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -33,8 +33,8 @@ repositories:
   # universe
   universe/autoware_universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware_universe.git
-    version: main
+    url: https://github.com/tier4/autoware_universe.git
+    version: bce507a28ecdf9f1da77ee4c57e385c219c31296
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -13,7 +13,7 @@ repositories:
   core/autoware_core:
     type: git
     url: https://github.com/tier4/autoware_core.git
-    version: e576dfcd3f738a6c4d973edcbb51041865394893
+    version: beta/v0.64
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -34,11 +34,11 @@ repositories:
   universe/autoware_universe:
     type: git
     url: https://github.com/tier4/autoware_universe.git
-    version: bce507a28ecdf9f1da77ee4c57e385c219c31296
+    version: beta/v0.64
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: v0.58.0
+    version: beta/v0.64
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -12,8 +12,8 @@ repositories:
     version: main
   core/autoware_core:
     type: git
-    url: https://github.com/autowarefoundation/autoware_core.git
-    version: main
+    url: https://github.com/tier4/autoware_core.git
+    version: beta/v0.64
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -29,7 +29,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.10.0
+    version: 0.12.0
   # universe
   universe/autoware_universe:
     type: git


### PR DESCRIPTION
## Description
Align the version of `autoware_core`, `autoware_universe`, and `autoware_lanelet2_extension` with the [autoware.repos](https://github.com/tier4/pilot-auto/blob/beta/v0.64/autoware.repos) in pilot.auto beta/v0.64.

## How was this PR tested?
None

## Notes for reviewers
None.

## Effects on system behavior
None.
