### PR TITLE
fix: cherry pick reproducer PRs for e2e reproducer tests

### DIFF
--- a/planning/planning_debug_tools/README.md
+++ b/planning/planning_debug_tools/README.md
@@ -202,6 +202,8 @@ The following topics are loaded from the rosbag and replayed:
 - `/perception/object_recognition/objects` (autoware_perception_msgs/msg/PredictedObjects): Predicted objects (default)
 - `/perception/traffic_light_recognition/traffic_signals` (autoware_perception_msgs/msg/TrafficLightGroupArray): Traffic light signals
 - `/perception/occupancy_grid_map/map` (nav_msgs/msg/OccupancyGrid): Occupancy grid map (with transient_local QoS)
+- `/planning/mission_planning/route` (autoware_planning_msgs/msg/LaneletRoute): Route data (with transient_local QoS, when `--replay-route` option is used)
+- `/planning/mission_planning/state` (autoware_planning_msgs/msg/RouteState): Route state data (with transient_local QoS, when `--replay-route` option is used)
 - `<any CompressedImage topic>` (sensor_msgs/msg/CompressedImage): Reference images for visualization (when `--reference-image-topics` is used)
 
 ### Published Topics
@@ -211,6 +213,8 @@ The following topics are published during replay:
 - `/perception/object_recognition/tracking/objects` or `/perception/object_recognition/objects`: Replayed perception objects
 - `/perception/traffic_light_recognition/traffic_signals`: Replayed traffic light signals
 - `/perception/occupancy_grid_map/map`: Replayed occupancy grid map (published with transient_local QoS, so late subscribers can receive the latest map)
+- `/planning/mission_planning/route`: Replayed route (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
+- `/planning/mission_planning/state`: Replayed route state (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
 - `<any CompressedImage topic>`: Replayed reference images (published to the same topic name as in the rosbag)
 - `/perception_reproducer/rosbag_ego_odom`: Debug topic for recorded ego odometry
 - `/initialpose`: Initial pose (when `-p` option is used)
@@ -234,6 +238,7 @@ This design results in the following behavior:
 - `-r`, `--search-radius`: Set the search radius in meters (default: 1.5m). If set to 0, always publishes the nearest message
 - `-c`, `--reproduce-cool-down`: Set the cool down time in seconds (default: 80.0s)
 - `-p`, `--pub-route`: Initialize localization and publish a route based on poses from the rosbag
+- `--replay-route`: Replay route and route state topics from rosbag data with transient_local QoS (only publishes when the message changes)
 - `-n`, `--noise`: Apply perception noise to objects when publishing repeated messages (default: False)
 - `-f`, `--rosbag-format`: Specify rosbag data format (default: "db3")
 - `--reference-image-topics`: Comma-separated list of CompressedImage topics to load and publish (e.g., `"/sensing/camera/camera0/image_raw/compressed,/sensing/camera/camera1/image_raw/compressed"`)
@@ -271,6 +276,14 @@ Example usage with route publication:
 ros2 run planning_debug_tools perception_reproducer -b <bag-file> -p
 ```
 
+The `--replay-route` option enables replaying of route and route state topics directly from the rosbag data. These topics use transient_local QoS and are only published when the message content changes (avoiding redundant publishes). This is useful when you want to replay the exact route that was recorded in the rosbag.
+
+Example usage with route replaying:
+
+```bash
+ros2 run planning_debug_tools perception_reproducer -b <bag-file> --replay-route
+```
+
 ## Perception replayer
 
 A part of the feature is under development.
@@ -290,6 +303,8 @@ The following topics are loaded from the rosbag and replayed:
 - `/perception/object_recognition/objects` (autoware_perception_msgs/msg/PredictedObjects): Predicted objects (default)
 - `/perception/traffic_light_recognition/traffic_signals` (autoware_perception_msgs/msg/TrafficLightGroupArray): Traffic light signals
 - `/perception/occupancy_grid_map/map` (nav_msgs/msg/OccupancyGrid): Occupancy grid map (with transient_local QoS)
+- `/planning/mission_planning/route` (autoware_planning_msgs/msg/LaneletRoute): Route data (with transient_local QoS, when `--replay-route` option is used)
+- `/planning/mission_planning/state` (autoware_planning_msgs/msg/RouteState): Route state data (with transient_local QoS, when `--replay-route` option is used)
 - `<any CompressedImage topic>` (sensor_msgs/msg/CompressedImage): Reference images for visualization
 
 ### Published Topics
@@ -299,6 +314,8 @@ The following topics are published during replay:
 - `/perception/object_recognition/tracking/objects` or `/perception/object_recognition/objects`: Replayed perception objects
 - `/perception/traffic_light_recognition/traffic_signals`: Replayed traffic light signals
 - `/perception/occupancy_grid_map/map`: Replayed occupancy grid map (published with transient_local QoS, so late subscribers can receive the latest map)
+- `/planning/mission_planning/route`: Replayed route (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
+- `/planning/mission_planning/state`: Replayed route state (published with transient_local QoS, only when the message changes; when `--replay-route` option is used)
 - `<any CompressedImage topic>`: Replayed reference images
 - `/perception_reproducer/rosbag_ego_odom`: Debug topic for recorded ego odometry
 
@@ -306,6 +323,7 @@ The following topics are published during replay:
 
 - `-b`, `--bag`: Rosbag file path (required)
 - `-t`, `--tracked-object`: Publish tracked objects
+- `--replay-route`: Replay route and route state topics from rosbag data with transient_local QoS (only publishes when the message changes)
 - `-f`, `--rosbag-format`: Specify rosbag data format (default: "db3")
 - `-v`, `--verbose`: Output debug data
 - `-h`, `--help`: Show help message

--- a/planning/planning_debug_tools/README.md
+++ b/planning/planning_debug_tools/README.md
@@ -222,6 +222,8 @@ The following topics are published during replay:
 
 ### How it works
 
+The node subscribes to `/localization/kinematic_state` for the simulator ego pose and `/initialpose3d` to align the rosbag replay timeline when localization is reset (e.g. DLR DirectInitialPose).
+
 Whenever the ego's position changes, a chronological `reproduce_sequence` queue is generated based on its position with a search radius (default to 2 m).
 If the queue is empty, the nearest odom message in the rosbag is added to the queue.
 When publishing perception messages, the first element in the `reproduce_sequence` is popped and published.

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -361,7 +361,7 @@ void PerceptionReplayerCommon::publish_topics_at_timestamp(
   }
 
   if (param_.replay_route) {
-    publish_route_at_timestamp(bag_timestamp);
+    publish_route_at_timestamp(bag_timestamp, current_timestamp);
   }
 }
 
@@ -414,7 +414,8 @@ void PerceptionReplayerCommon::publish_reference_images_at_timestamp(
   }
 }
 
-void PerceptionReplayerCommon::publish_route_at_timestamp(const rclcpp::Time & bag_timestamp)
+void PerceptionReplayerCommon::publish_route_at_timestamp(
+  const rclcpp::Time & bag_timestamp, const rclcpp::Time & current_timestamp)
 {
   // Helper: find the index of the last message at or before bag_timestamp.
   // Returns nullopt if there is no such message.
@@ -440,17 +441,32 @@ void PerceptionReplayerCommon::publish_route_at_timestamp(const rclcpp::Time & b
   if (!rosbag_route_data_.empty()) {
     const auto idx = find_last_before(rosbag_route_data_, bag_timestamp);
     if (idx.has_value() && last_published_route_idx_ != idx.value()) {
-      route_pub_->publish(rosbag_route_data_[idx.value()].second);
+      auto route_msg = rosbag_route_data_[idx.value()].second;
+      route_msg.header.stamp = current_timestamp;
+      route_pub_->publish(route_msg);
       last_published_route_idx_ = idx.value();
     }
   }
 
-  // route state
+  // route state: publish when bag index changes, or re-publish every 5s (replay time)
   if (!rosbag_route_state_data_.empty()) {
     const auto idx = find_last_before(rosbag_route_state_data_, bag_timestamp);
-    if (idx.has_value() && last_published_route_state_idx_ != idx.value()) {
-      route_state_pub_->publish(rosbag_route_state_data_[idx.value()].second);
-      last_published_route_state_idx_ = idx.value();
+    if (idx.has_value()) {
+      const bool index_changed = !last_published_route_state_idx_.has_value() ||
+                                 last_published_route_state_idx_.value() != idx.value();
+      constexpr double k_route_state_republish_period_sec = 10.0;
+      const bool period_elapsed =
+        !last_route_state_publish_replay_time_.has_value() ||
+        (current_timestamp - last_route_state_publish_replay_time_.value()).seconds() >=
+          k_route_state_republish_period_sec;
+
+      if (index_changed || period_elapsed) {
+        auto route_state_msg = rosbag_route_state_data_[idx.value()].second;
+        route_state_msg.stamp = current_timestamp;
+        route_state_pub_->publish(route_state_msg);
+        last_published_route_state_idx_ = idx.value();
+        last_route_state_publish_replay_time_ = current_timestamp;
+      }
     }
   }
 }

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -112,6 +112,8 @@ void PerceptionReplayerCommon::load_rosbag(
   const std::string ego_odom_topic = "/localization/kinematic_state";
   const std::string traffic_signals_topic = "/perception/traffic_light_recognition/traffic_signals";
   const std::string occupancy_grid_topic = "/perception/occupancy_grid_map/map";
+  const std::string route_topic = "/planning/mission_planning/route";
+  const std::string route_state_topic = "/planning/mission_planning/state";
 
   // create topic filter
   rosbag2_storage::StorageFilter storage_filter;
@@ -121,6 +123,11 @@ void PerceptionReplayerCommon::load_rosbag(
     traffic_signals_topic,
     occupancy_grid_topic,
   };
+
+  if (param_.replay_route) {
+    storage_filter.topics.push_back(route_topic);
+    storage_filter.topics.push_back(route_state_topic);
+  }
 
   // Add reference image topics to filter
   for (const auto & topic : param_.reference_image_topics) {
@@ -173,6 +180,22 @@ void PerceptionReplayerCommon::load_rosbag(
             utils::deserialize_message<OccupancyGrid>(bag_message->serialized_data);
           const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
           rosbag_occupancy_grid_data_.emplace_back(timestamp, *occupancy_grid_msg);
+        }
+
+        // deserialize route messages
+        if (bag_message->topic_name == route_topic) {
+          const auto route_msg =
+            utils::deserialize_message<LaneletRoute>(bag_message->serialized_data);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
+          rosbag_route_data_.emplace_back(timestamp, *route_msg);
+        }
+
+        // deserialize route_state messages
+        if (bag_message->topic_name == route_state_topic) {
+          const auto route_state_msg =
+            utils::deserialize_message<RouteState>(bag_message->serialized_data);
+          const rclcpp::Time timestamp(get_timestamp_ns(*bag_message));
+          rosbag_route_state_data_.emplace_back(timestamp, *route_state_msg);
         }
 
         // deserialize reference image messages
@@ -258,6 +281,15 @@ PerceptionReplayerCommon::PerceptionReplayerCommon(
   occupancy_grid_pub_ =
     this->create_publisher<OccupancyGrid>("/perception/occupancy_grid_map/map", occupancy_grid_qos);
 
+  if (param_.replay_route) {
+    rclcpp::QoS transient_local_qos(1);
+    transient_local_qos.transient_local();
+    route_pub_ =
+      this->create_publisher<LaneletRoute>("/planning/mission_planning/route", transient_local_qos);
+    route_state_pub_ =
+      this->create_publisher<RouteState>("/planning/mission_planning/state", transient_local_qos);
+  }
+
   recorded_ego_as_initialpose_pub_ =
     this->create_publisher<PoseWithCovarianceStamped>("/initialpose", 1);
   goal_as_mission_planning_goal_pub_ =
@@ -327,6 +359,10 @@ void PerceptionReplayerCommon::publish_topics_at_timestamp(
     msg.header.stamp = current_timestamp;
     occupancy_grid_pub_->publish(msg);
   }
+
+  if (param_.replay_route) {
+    publish_route_at_timestamp(bag_timestamp);
+  }
 }
 
 void PerceptionReplayerCommon::publish_traffic_lights_at_timestamp(
@@ -374,6 +410,47 @@ void PerceptionReplayerCommon::publish_reference_images_at_timestamp(
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), 5000, "No reference image found for topic %s at timestamp %f",
         topic.c_str(), bag_timestamp.seconds());
+    }
+  }
+}
+
+void PerceptionReplayerCommon::publish_route_at_timestamp(const rclcpp::Time & bag_timestamp)
+{
+  // Helper: find the index of the last message at or before bag_timestamp.
+  // Returns nullopt if there is no such message.
+  auto find_last_before = [](const auto & data, const rclcpp::Time & ts) -> std::optional<size_t> {
+    if (data.empty() || data.front().first > ts) {
+      return std::nullopt;
+    }
+    // binary search for rightmost element with timestamp <= ts
+    size_t lo = 0;
+    size_t hi = data.size();
+    while (lo < hi) {
+      const size_t mid = lo + (hi - lo) / 2;
+      if (data[mid].first <= ts) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo - 1;
+  };
+
+  // route
+  if (!rosbag_route_data_.empty()) {
+    const auto idx = find_last_before(rosbag_route_data_, bag_timestamp);
+    if (idx.has_value() && last_published_route_idx_ != idx.value()) {
+      route_pub_->publish(rosbag_route_data_[idx.value()].second);
+      last_published_route_idx_ = idx.value();
+    }
+  }
+
+  // route state
+  if (!rosbag_route_state_data_.empty()) {
+    const auto idx = find_last_before(rosbag_route_state_data_, bag_timestamp);
+    if (idx.has_value() && last_published_route_state_idx_ != idx.value()) {
+      route_state_pub_->publish(rosbag_route_state_data_[idx.value()].second);
+      last_published_route_state_idx_ = idx.value();
     }
   }
 }

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
@@ -42,6 +42,7 @@ struct PerceptionReplayerCommonParam
   std::string rosbag_path;
   std::string rosbag_format;
   bool tracked_object;
+  bool replay_route;
   std::vector<std::string> reference_image_topics;  // Topics for reference images
 };
 
@@ -118,6 +119,13 @@ public:
   void publish_reference_images_at_timestamp(
     const rclcpp::Time & bag_timestamp, const rclcpp::Time & current_timestamp);
 
+  /**
+   * @brief Publish route and route state (transient_local) at the given timestamp.
+   * Only publishes when the message to publish differs from the last published one.
+   * @param bag_timestamp
+   */
+  void publish_route_at_timestamp(const rclcpp::Time & bag_timestamp);
+
 protected:
   const PerceptionReplayerCommonParam param_;
 
@@ -187,6 +195,8 @@ protected:
   std::vector<utils::DataStamped<TrackedObjects>> rosbag_tracked_objects_data_;
   std::vector<utils::DataStamped<TrafficLightGroupArray>> rosbag_traffic_signals_data_;
   std::vector<utils::DataStamped<OccupancyGrid>> rosbag_occupancy_grid_data_;
+  std::vector<utils::DataStamped<LaneletRoute>> rosbag_route_data_;
+  std::vector<utils::DataStamped<RouteState>> rosbag_route_state_data_;
 
   // Reference image data: topic name -> timestamped messages
   std::unordered_map<std::string, std::vector<utils::DataStamped<CompressedImage>>>
@@ -215,6 +225,12 @@ protected:
   rclcpp::PublisherBase::SharedPtr objects_pub_;
   rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr traffic_signals_pub_;
   rclcpp::Publisher<OccupancyGrid>::SharedPtr occupancy_grid_pub_;
+  rclcpp::Publisher<LaneletRoute>::SharedPtr route_pub_;
+  rclcpp::Publisher<RouteState>::SharedPtr route_state_pub_;
+
+  // track last published index to avoid redundant publishes for transient_local topics
+  std::optional<size_t> last_published_route_idx_;
+  std::optional<size_t> last_published_route_state_idx_;
 
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr recorded_ego_as_initialpose_pub_;
   rclcpp::Publisher<PoseStamped>::SharedPtr goal_as_mission_planning_goal_pub_;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
@@ -122,9 +122,11 @@ public:
   /**
    * @brief Publish route and route state (transient_local) at the given timestamp.
    * Only publishes when the message to publish differs from the last published one.
-   * @param bag_timestamp
+   * @param bag_timestamp Used to select messages from the rosbag.
+   * @param current_timestamp Stamp written on published messages (replay clock).
    */
-  void publish_route_at_timestamp(const rclcpp::Time & bag_timestamp);
+  void publish_route_at_timestamp(
+    const rclcpp::Time & bag_timestamp, const rclcpp::Time & current_timestamp);
 
 protected:
   const PerceptionReplayerCommonParam param_;
@@ -231,6 +233,8 @@ protected:
   // track last published index to avoid redundant publishes for transient_local topics
   std::optional<size_t> last_published_route_idx_;
   std::optional<size_t> last_published_route_state_idx_;
+  /// Last time route_state was published (replay clock); used for periodic re-publish.
+  std::optional<rclcpp::Time> last_route_state_publish_replay_time_;
 
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr recorded_ego_as_initialpose_pub_;
   rclcpp::Publisher<PoseStamped>::SharedPtr goal_as_mission_planning_goal_pub_;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_node.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_node.cpp
@@ -77,6 +77,12 @@ int main(int argc, char * argv[])
       "rosbag data format", "{sqlite3,mcap}", "sqlite3");
     options << rosbag_format_option;
 
+    QCommandLineOption replay_route_option(
+      QStringList() << "replay-route",
+      "replay route and route state topics from rosbag data with transient_local QoS. "
+      "Only publishes when the message changes (i.e., not redundantly).");
+    options << replay_route_option;
+
     for (const auto & option : options) {
       parser.addOption(option);
     }
@@ -109,6 +115,7 @@ int main(int argc, char * argv[])
     }
 
     perception_replayer_param.tracked_object = parser.isSet(tracked_object_option);
+    perception_replayer_param.replay_route = parser.isSet(replay_route_option);
 
     rclcpp::NodeOptions node_options;
     auto node = std::make_shared<PerceptionReplayer>(perception_replayer_param, node_options);

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
@@ -37,10 +37,10 @@ PerceptionReproducer::PerceptionReproducer(
 
   ego_odom_search_radius_ = param_.search_radius;
 
-  // subscription for /initialpose to refresh cool down
+  // subscription for /initialpose3d to refresh cool down and sync bag anchor
   sub_init_pos_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "/initialpose", 1,
-    std::bind(&PerceptionReproducer::on_initialpose, this, std::placeholders::_1));
+    "/initialpose3d", 1,
+    std::bind(&PerceptionReproducer::on_pose_reset, this, std::placeholders::_1));
 
   // calculate average ego odom interval
   RCLCPP_INFO(get_logger(), "Calculating average ego odom interval");
@@ -72,10 +72,9 @@ PerceptionReproducer::PerceptionReproducer(
   RCLCPP_INFO(get_logger(), "PerceptionReproducer initialization completed");
 }
 
-void PerceptionReproducer::on_initialpose(
+void PerceptionReproducer::on_pose_reset(
   const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
 {
-  (void)msg;
   cool_down_indices_.clear();
 
   last_sequenced_ego_pose_.reset();
@@ -85,7 +84,7 @@ void PerceptionReproducer::on_initialpose(
     last_published_timestamp_ = rosbag_ego_odom_data_[nearest_ego_odom_idx].first;
   }
 
-  RCLCPP_INFO(get_logger(), "Cool down indices and last sequenced pose cleared by /initialpose");
+  RCLCPP_INFO(get_logger(), "Cool down indices and last sequenced pose cleared by /initialpose3d");
 }
 
 void PerceptionReproducer::on_timer()
@@ -198,6 +197,14 @@ void PerceptionReproducer::on_timer()
       cool_down_indices_.push_back(ego_odom_idx);
 
       return pose_timestamp;
+    }
+
+    if (!last_published_timestamp_.has_value()) {
+      const auto idx = find_nearest_ego_odom_index(ego_pose);
+      last_published_timestamp_ = rosbag_ego_odom_data_[idx].first;
+      RCLCPP_INFO(
+        get_logger(), "Seeded bag timestamp from ego pose (idx=%zu, t=%.3f)", idx,
+        last_published_timestamp_->seconds());
     }
 
     return last_published_timestamp_;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.hpp
@@ -47,7 +47,7 @@ public:
 
 private:
   void on_timer();
-  void on_initialpose(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+  void on_pose_reset(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
 
   // find nearest ego odom index by position
   size_t find_nearest_ego_odom_index(const geometry_msgs::msg::Pose & ego_pose) const;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer_node.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer_node.cpp
@@ -99,6 +99,12 @@ int main(int argc, char ** argv)
       "end of the rosbag. By default, route are not published.");
     options << pub_route_option;
 
+    const QCommandLineOption replay_route_option(
+      QStringList() << "replay-route",
+      "replay route and route state topics from rosbag data with transient_local QoS. "
+      "Only publishes when the message changes (i.e., not redundantly).");
+    options << replay_route_option;
+
     const QCommandLineOption verbose_option(
       QStringList() << "v"
                     << "verbose",
@@ -141,6 +147,7 @@ int main(int argc, char ** argv)
     param.noise = parser.isSet(noise_option);
     param.verbose = parser.isSet(verbose_option);
     param.publish_route = parser.isSet(pub_route_option);
+    param.replay_route = parser.isSet(replay_route_option);
 
     // Parse comma-separated reference image topics
     const QString topics_str = parser.value(ref_image_topics_option);

--- a/planning/planning_debug_tools/src/perception_replayer/type_alias.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/type_alias.hpp
@@ -18,6 +18,8 @@
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
@@ -32,6 +34,8 @@ using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::TrackedObjects;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::RouteState;
 using geometry_msgs::msg::PoseStamped;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 using nav_msgs::msg::OccupancyGrid;


### PR DESCRIPTION
## Description
Cherry-pick the following PRs for testing E2E planning with the latest PerceptionReproducer:
- https://github.com/autowarefoundation/autoware_tools/pull/446
- https://github.com/autowarefoundation/autoware_tools/pull/374
- https://github.com/autowarefoundation/autoware_tools/pull/369

## How was this PR tested?
[Evaluator](https://evaluation.tier4.jp/evaluation/reports/a2c8a9cb-4602-5937-ac20-7d708c252868/tests/1d3e5775-485a-5885-bdb0-12f73b019ff1?project_id=x2_dev)


## Notes for reviewers

None.

## Effects on system behavior

None.
