### PR TITLE
chore: update `build_depends.repos` for beta build dependencies

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -26,13 +26,13 @@ repositories:
     version: 1.1.0
   core/autoware_core:
     type: git
-    url: https://github.com/autowarefoundation/autoware_core.git
-    version: main
+    url: https://github.com/tier4/autoware_core.git
+    version: beta/v0.68
   # universe
   universe/autoware_universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware_universe.git
-    version: main
+    url: https://github.com/tier4/autoware_universe.git
+    version: beta/v0.68
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git


### PR DESCRIPTION
## Description

Update `build_depends.repos` for betas.

`tier4_autoware_msgs` release is omitted, so the version pinning is skipped. Might pin the version / tag the release later if the CI is problematic.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
