### PR TITLE
feat: create service to allow republish initialization and route

### DIFF
--- a/planning/planning_debug_tools/README.md
+++ b/planning/planning_debug_tools/README.md
@@ -286,6 +286,14 @@ Example usage with route replaying:
 ros2 run planning_debug_tools perception_reproducer -b <bag-file> --replay-route
 ```
 
+While the node is running, you can republish localization and route without restarting:
+
+```bash
+ros2 service call /perception_reproducer/republish_route std_srvs/srv/Trigger {}
+```
+
+This publishes `/initialpose` from the rosbag start and `/planning/mission_planning/goal` from the rosbag end, same as the `-p` option at startup. The reproduce cool-down state is also reset.
+
 ## Perception replayer
 
 A part of the feature is under development.

--- a/planning/planning_debug_tools/package.xml
+++ b/planning/planning_debug_tools/package.xml
@@ -40,6 +40,7 @@
   <depend>rosbag2_storage</depend>
   <depend>rosbag2_transport</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>tier4_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -539,6 +539,15 @@ void PerceptionReplayerCommon::publish_goal_pose()
   RCLCPP_INFO(get_logger(), "Published last recorded ego pose as /planning/mission_planning/goal");
 }
 
+void PerceptionReplayerCommon::publish_localization_and_route()
+{
+  publish_recorded_ego_pose(get_bag_start_time());
+  // temporarily add a sleep because sometimes the route is not generated correctly without it.
+  // Need to consider a proper solution.
+  rclcpp::sleep_for(std::chrono::seconds(2));
+  publish_goal_pose();
+}
+
 void PerceptionReplayerCommon::on_ego_odom(const Odometry::SharedPtr msg)
 {
   ego_odom_ = msg;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.hpp
@@ -98,6 +98,11 @@ public:
    */
   void publish_goal_pose();
 
+  /**
+   * @brief Publish initial pose from bag start and goal pose from bag end
+   */
+  void publish_localization_and_route();
+
   std::optional<Odometry> get_latest_ego_odom() const
   {
     return ego_odom_ ? std::make_optional<Odometry>(*ego_odom_) : std::nullopt;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
@@ -103,10 +103,23 @@ void PerceptionReproducer::on_republish_route_service(
   }
 
   reset_reproduce_state();
-  publish_localization_and_route();
+
+  if (param_.publish_route) {
+    publish_localization_and_route();
+    response->message = "Republished /initialpose and /planning/mission_planning/goal from rosbag.";
+  }
+
+  if (param_.replay_route) {
+    // publish locaization rest
+    publish_recorded_ego_pose(get_bag_start_time());
+
+    const auto bag_timestamp = rosbag_ego_odom_data_.front().first;
+    publish_route_at_timestamp(bag_timestamp, this->get_clock()->now());
+    response->message =
+      "Republished /initialpose and /planning/mission_planning/route from rosbag.";
+  }
 
   response->success = true;
-  response->message = "Republished /initialpose and /planning/mission_planning/goal from rosbag.";
   RCLCPP_INFO(get_logger(), "%s", response->message.c_str());
 }
 

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
@@ -61,12 +61,13 @@ PerceptionReproducer::PerceptionReproducer(
     this, get_clock(), std::chrono::duration<double>(average_ego_odom_interval),
     std::bind(&PerceptionReproducer::on_timer, this), callback_group_check_perception_);
 
+  republish_route_srv_ = this->create_service<std_srvs::srv::Trigger>(
+    "~/republish_route", std::bind(
+                           &PerceptionReproducer::on_republish_route_service, this,
+                           std::placeholders::_1, std::placeholders::_2));
+
   if (param_.publish_route) {
-    publish_recorded_ego_pose(get_bag_start_time());
-    // temporarily add a sleep because sometimes the route is not generated correctly without it.
-    // Need to consider a proper solution.
-    rclcpp::sleep_for(std::chrono::seconds(2));
-    publish_goal_pose();
+    publish_localization_and_route();
   }
 
   RCLCPP_INFO(get_logger(), "PerceptionReproducer initialization completed");
@@ -75,9 +76,7 @@ PerceptionReproducer::PerceptionReproducer(
 void PerceptionReproducer::on_pose_reset(
   const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
 {
-  cool_down_indices_.clear();
-
-  last_sequenced_ego_pose_.reset();
+  reset_reproduce_state();
 
   if (!last_published_timestamp_.has_value()) {
     const auto nearest_ego_odom_idx = find_nearest_ego_odom_index(msg->pose.pose);
@@ -85,6 +84,30 @@ void PerceptionReproducer::on_pose_reset(
   }
 
   RCLCPP_INFO(get_logger(), "Cool down indices and last sequenced pose cleared by /initialpose3d");
+}
+
+void PerceptionReproducer::reset_reproduce_state()
+{
+  cool_down_indices_.clear();
+  last_sequenced_ego_pose_.reset();
+}
+
+void PerceptionReproducer::on_republish_route_service(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+  const std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  if (rosbag_ego_odom_data_.empty()) {
+    response->success = false;
+    response->message = "No ego odom data loaded from rosbag.";
+    return;
+  }
+
+  reset_reproduce_state();
+  publish_localization_and_route();
+
+  response->success = true;
+  response->message = "Republished /initialpose and /planning/mission_planning/goal from rosbag.";
+  RCLCPP_INFO(get_logger(), "%s", response->message.c_str());
 }
 
 void PerceptionReproducer::on_timer()

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.hpp
@@ -21,8 +21,10 @@
 
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 #include <deque>
+#include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -48,6 +50,10 @@ public:
 private:
   void on_timer();
   void on_pose_reset(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+  void on_republish_route_service(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    const std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void reset_reproduce_state();
 
   // find nearest ego odom index by position
   size_t find_nearest_ego_odom_index(const geometry_msgs::msg::Pose & ego_pose) const;
@@ -66,6 +72,9 @@ private:
 
   // subscription
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_init_pos_;
+
+  // service
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr republish_route_srv_;
 
   // state management
   std::deque<size_t> reproduce_sequence_indices_;


### PR DESCRIPTION
## Description

Add a `std_srvs/srv/Trigger` service to `perception_reproducer` so localization and route can be republished at runtime without restarting the node.

**Changes:**
- Expose `~/republish_route` service on `perception_reproducer`
- Extract shared `publish_localization_and_route()` in `PerceptionReplayerCommon` (publishes `/initialpose` from bag start, waits 2 s, then publishes `/planning/mission_planning/goal` from bag end — same behavior as the `-p` / `--pub-route` startup option)
- Extract `reset_reproduce_state()` to clear cool-down indices and last sequenced pose; reused by `/initialpose3d` callback and the new service
- Add `std_srvs` dependency and document the service in README

**Usage while the node is running:**

```bash
ros2 service call /perception_reproducer/republish_route std_srvs/srv/Trigger {}
```

## How was this PR tested?

- [x] Built `planning_debug_tools` with colcon
- [ ] Launched `perception_reproducer` with `-p` or "replay route" on a rosbag and confirmed startup route publication still works
- [x] Called `/perception_reproducer/republish_route` at runtime and verified:
  - `/initialpose` is republished from the bag start pose
  - `/planning/mission_planning/goal` is republished from the bag end pose
  - Reproduce cool-down state is reset (same as receiving `/initialpose3d`)
  - Service returns `success: true` with an informative message
- [x] Verified service returns `success: false` when no ego odom data is loaded from the bag

## Notes for reviewers

- The 2-second sleep before publishing the goal pose is inherited from the existing `-p` startup path (known workaround for route generation timing). No change to that behavior.
- `reset_reproduce_state()` is now shared between the `/initialpose3d` subscription and the new service callback; logic is unchanged, only refactored.

## Effects on system behavior

When `perception_reproducer` is running, calling `~/republish_route` republishes initial pose and mission goal from the loaded rosbag and resets reproduce cool-down state. No effect unless the service is explicitly called. Default startup behavior with `-p` is unchanged.