### PR TITLE
fix(planning_data_analyzer): backport EPDMS gate

### DIFF
--- a/planning/autoware_planning_data_analyzer/CMakeLists.txt
+++ b/planning/autoware_planning_data_analyzer/CMakeLists.txt
@@ -16,7 +16,9 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/metrics/geometry/lanelet_geometry.cpp
   src/metrics/geometry/lanelet_queries.cpp
   src/metrics/geometry/object_tracks.cpp
+  src/metrics/geometry/trajectory_utils.cpp
   src/metrics/epdms/aggregation/epdms_aggregation.cpp
+  src/metrics/epdms/debug/epdms_debug_writer.cpp
   src/metrics/epdms/subscores/ego_progress.cpp
   src/metrics/epdms/subscores/driving_direction_compliance.cpp
   src/metrics/epdms/subscores/history_comfort.cpp

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -82,6 +82,7 @@ Key parameters in `config/planning_data_analyzer.param.yaml`:
 - `evaluation_interval_ms`: Sampling interval (default: 100ms)
 - `sync_tolerance_ms`: Time synchronization tolerance (default: 100ms)
 - `trajectory_topic`: Trajectory topic to evaluate
+- `open_loop.enable_epdms_calculation`: Enables EPDMS subscore, synthetic EPDMS, and EPDMS debug calculation
 - `open_loop.*`: Open-loop specific settings
 
 ---

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -47,6 +47,8 @@
       # Debug visualization topics are expensive and disabled by default.
       # This switch is reserved for the follow-up debug-topic PR.
       debug_topics_enabled: false
+      # Disable to skip EPDMS subscore, synthetic EPDMS, and EPDMS debug calculations.
+      enable_epdms_calculation: true
       # Maximum planned trajectory duration to evaluate [s].
       # 0.0 means use the full trajectory from the bag.
       trajectory_evaluation_horizon: 4.0

--- a/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
+++ b/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
@@ -9,6 +9,7 @@
   <arg name="gt_source_mode" default="kinematic_state" description="GT source mode: kinematic_state or gt_trajectory"/>
   <arg name="gt_trajectory_topic" default="/planning/ground_truth_trajectory" description="GT trajectory topic for gt_trajectory mode"/>
   <arg name="gt_sync_tolerance_ms" default="200.0" description="Sync tolerance (ms) for GT trajectory alignment"/>
+  <arg name="enable_epdms_calculation" default="true" description="Enable EPDMS calculation and EPDMS debug outputs"/>
 
   <group if="$(eval '&quot;$(var vehicle_model)&quot; != &quot;&quot;')">
     <node pkg="autoware_planning_data_analyzer" exec="autoware_planning_data_analyzer_node" name="autoware_planning_data_analyzer" output="screen">
@@ -21,6 +22,7 @@
       <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
+      <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>
@@ -35,6 +37,7 @@
       <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
+      <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>

--- a/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
+++ b/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
@@ -10,6 +10,7 @@
   <arg name="gt_trajectory_topic" default="/planning/ground_truth_trajectory" description="GT trajectory topic for gt_trajectory mode"/>
   <arg name="gt_sync_tolerance_ms" default="200.0" description="Sync tolerance (ms) for GT trajectory alignment"/>
   <arg name="enable_epdms_calculation" default="true" description="Enable EPDMS calculation and EPDMS debug outputs"/>
+  <arg name="debug_topics_enabled" default="false" description="Enable EPDMS debug topic outputs"/>
 
   <group if="$(eval '&quot;$(var vehicle_model)&quot; != &quot;&quot;')">
     <node pkg="autoware_planning_data_analyzer" exec="autoware_planning_data_analyzer_node" name="autoware_planning_data_analyzer" output="screen">
@@ -23,6 +24,7 @@
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
       <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
+      <param name="open_loop.debug_topics_enabled" value="$(var debug_topics_enabled)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>
@@ -38,6 +40,7 @@
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
       <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
+      <param name="open_loop.debug_topics_enabled" value="$(var debug_topics_enabled)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>

--- a/planning/autoware_planning_data_analyzer/package.xml
+++ b/planning/autoware_planning_data_analyzer/package.xml
@@ -27,8 +27,11 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
   <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_utils_uuid</depend>
+  <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>nlohmann-json-dev</depend>

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -124,6 +124,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   enabled_metric_names_ =
     get_or_declare_parameter<std::vector<std::string>>(*this, "open_loop.enabled_metrics");
   debug_topics_enabled_ = get_or_declare_parameter<bool>(*this, "open_loop.debug_topics_enabled");
+  enable_epdms_calculation_ =
+    get_or_declare_parameter<bool>(*this, "open_loop.enable_epdms_calculation");
   trajectory_evaluation_horizon_s_ =
     get_or_declare_parameter<double>(*this, "open_loop.trajectory_evaluation_horizon");
   history_comfort_params_.past_horizon_s =
@@ -526,6 +528,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       evaluator.set_json_output_dir(output_dir_path.string());
       evaluator.set_metric_variant(open_loop_metric_variant);
       evaluator.set_enabled_metrics(enabled_metric_names_);
+      evaluator.set_epdms_calculation_enabled(enable_epdms_calculation_);
       evaluator.set_debug_topics_enabled(debug_topics_enabled_);
       evaluator.set_trajectory_evaluation_horizon(trajectory_evaluation_horizon_s_);
       evaluator.set_evaluation_horizons(evaluation_horizons);

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -90,6 +90,7 @@ private:
   double gt_sync_tolerance_ms_ = 200.0;
   std::vector<std::string> enabled_metric_names_;
   bool debug_topics_enabled_ = false;
+  bool enable_epdms_calculation_ = true;
   double trajectory_evaluation_horizon_s_ = 4.0;
   metrics::HistoryComfortParameters history_comfort_params_;
   metrics::ExtendedComfortParameters extended_comfort_parameters_;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/debug/epdms_debug_writer.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/debug/epdms_debug_writer.cpp
@@ -1,0 +1,1067 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "epdms_debug_writer.hpp"
+
+#include "metrics/geometry/ego_footprint.hpp"
+#include "metrics/geometry/metric_utils.hpp"
+#include "metrics/geometry/trajectory_utils.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
+#include <nlohmann/json.hpp>
+#include <rclcpp/duration.hpp>
+
+#include <std_msgs/msg/float64_multi_array.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics
+{
+namespace
+{
+
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+constexpr double kDebugMarkerLifetimeS = 0.2;
+
+std::string debug_topic(const std::string & subscore, const std::string & name)
+{
+  return "/debug/epdms/" + subscore + "/" + name;
+}
+
+std::string trajectory_debug_topic(const std::string & name)
+{
+  return debug_topic("trajectory", name);
+}
+
+std_msgs::msg::ColorRGBA make_color(
+  const float red, const float green, const float blue, const float alpha = 1.0F)
+{
+  return autoware_utils_visualization::create_marker_color(red, green, blue, alpha);
+}
+
+Marker make_marker_base(
+  const rclcpp::Time & stamp, const std::string & ns, const int id, const int type,
+  const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & marker_color,
+  const double lifetime_s)
+{
+  auto marker = autoware_utils_visualization::create_default_marker(
+    "map", stamp, ns, id, type, scale, marker_color);
+  marker.lifetime = rclcpp::Duration::from_seconds(lifetime_s);
+  return marker;
+}
+
+Marker make_delete_all_marker(const rclcpp::Time & stamp)
+{
+  auto marker = autoware_utils_visualization::create_deleted_default_marker(stamp, "", 0);
+  marker.header.frame_id = "map";
+  marker.action = Marker::DELETEALL;
+  return marker;
+}
+
+std::string join_strings(const std::vector<std::string> & values, const std::string & separator)
+{
+  std::string joined;
+  for (const auto & value : values) {
+    if (!joined.empty()) {
+      joined += separator;
+    }
+    joined += value;
+  }
+  return joined;
+}
+
+std::vector<geometry_msgs::msg::Point> closed_line_strip_points(
+  std::vector<geometry_msgs::msg::Point> points)
+{
+  if (points.size() < 2U) {
+    return points;
+  }
+  const auto & first = points.front();
+  const auto & last = points.back();
+  if (first.x != last.x || first.y != last.y || first.z != last.z) {
+    points.push_back(first);
+  }
+  return points;
+}
+
+std::vector<geometry_msgs::msg::Point> lift_points(
+  std::vector<geometry_msgs::msg::Point> points, const double z_offset)
+{
+  for (auto & point : points) {
+    point.z += z_offset;
+  }
+  return points;
+}
+
+std::vector<geometry_msgs::msg::Point> square_marker_points(
+  const geometry_msgs::msg::Point & center, const double half_extent)
+{
+  geometry_msgs::msg::Point p0 = center;
+  geometry_msgs::msg::Point p1 = center;
+  geometry_msgs::msg::Point p2 = center;
+  geometry_msgs::msg::Point p3 = center;
+  p0.x -= half_extent;
+  p0.y -= half_extent;
+  p1.x += half_extent;
+  p1.y -= half_extent;
+  p2.x += half_extent;
+  p2.y += half_extent;
+  p3.x -= half_extent;
+  p3.y += half_extent;
+  return {p0, p1, p2, p3, p0};
+}
+
+Marker make_line_strip_marker(
+  const rclcpp::Time & stamp, const std::string & ns, const int id,
+  std::vector<geometry_msgs::msg::Point> points, const std_msgs::msg::ColorRGBA & marker_color,
+  const double width, const bool close_line, const double lifetime_s, const double z_offset = 0.0)
+{
+  auto marker = make_marker_base(
+    stamp, ns, id, Marker::LINE_STRIP,
+    autoware_utils_visualization::create_marker_scale(width, 0.0, 0.0), marker_color, lifetime_s);
+  marker.points = close_line ? closed_line_strip_points(std::move(points)) : std::move(points);
+  marker.points = lift_points(std::move(marker.points), z_offset);
+  return marker;
+}
+
+Marker make_filled_polygon_marker(
+  const rclcpp::Time & stamp, const std::string & ns, const int id,
+  std::vector<geometry_msgs::msg::Point> polygon_points,
+  const std_msgs::msg::ColorRGBA & marker_color, const double lifetime_s,
+  const double z_offset = 0.0)
+{
+  auto marker = make_marker_base(
+    stamp, ns, id, Marker::TRIANGLE_LIST,
+    autoware_utils_visualization::create_marker_scale(1.0, 1.0, 1.0), marker_color, lifetime_s);
+  if (polygon_points.size() >= 2U) {
+    const auto & first = polygon_points.front();
+    const auto & last = polygon_points.back();
+    if (first.x == last.x && first.y == last.y && first.z == last.z) {
+      polygon_points.pop_back();
+    }
+  }
+  if (polygon_points.size() < 3U) {
+    return marker;
+  }
+  marker.points.reserve((polygon_points.size() - 2U) * 3U);
+  for (std::size_t index = 1; index + 1U < polygon_points.size(); ++index) {
+    marker.points.push_back(polygon_points.front());
+    marker.points.push_back(polygon_points.at(index));
+    marker.points.push_back(polygon_points.at(index + 1U));
+  }
+  marker.points = lift_points(std::move(marker.points), z_offset);
+  return marker;
+}
+
+void write_string(
+  const nlohmann::json & json, const std::string & topic, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & timestamp)
+{
+  std_msgs::msg::String msg;
+  msg.data = json.dump();
+  bag_writer.write(msg, topic, timestamp);
+}
+
+void write_array(
+  const std::vector<double> & values, const std::string & topic, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & timestamp)
+{
+  std_msgs::msg::Float64MultiArray msg;
+  msg.data = values;
+  bag_writer.write(msg, topic, timestamp);
+}
+
+void add_marker_topic(
+  std::vector<std::pair<std::string, std::string>> & topics, const std::string & topic)
+{
+  topics.emplace_back(topic, "visualization_msgs/msg/MarkerArray");
+}
+
+void add_string_topic(
+  std::vector<std::pair<std::string, std::string>> & topics, const std::string & topic)
+{
+  topics.emplace_back(topic, "std_msgs/msg/String");
+}
+
+void add_array_topic(
+  std::vector<std::pair<std::string, std::string>> & topics, const std::string & topic)
+{
+  topics.emplace_back(topic, "std_msgs/msg/Float64MultiArray");
+}
+
+const NoAtFaultCollisionDebugEvent * find_worst_nc_event(
+  const NoAtFaultCollisionDebugInfo & debug_info)
+{
+  const NoAtFaultCollisionDebugEvent * worst_event = nullptr;
+  for (const auto & event : debug_info.events) {
+    if (!worst_event || event.event_score < worst_event->event_score) {
+      worst_event = &event;
+      continue;
+    }
+    if (event.event_score == worst_event->event_score && event.at_fault && !worst_event->at_fault) {
+      worst_event = &event;
+    }
+  }
+  return worst_event;
+}
+
+nlohmann::json nc_debug_event_to_json(const NoAtFaultCollisionDebugEvent & event)
+{
+  return nlohmann::json{
+    {"time_s", event.time_s},
+    {"object_id", event.object_id},
+    {"object_label", event.object_label},
+    {"collision_type", event.collision_type},
+    {"reason", event.reason},
+    {"agent", event.agent},
+    {"at_fault", event.at_fault},
+    {"score", event.event_score},
+    {"ego_stopped", event.ego_stopped},
+    {"track_stopped", event.track_stopped},
+    {"behind", event.behind},
+    {"front_hit", event.front_hit},
+    {"multiple_lanes", event.multiple_lanes},
+    {"non_drivable_area", event.non_drivable_area}};
+}
+
+nlohmann::json nc_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const NoAtFaultCollisionDebugInfo & debug_info,
+  const NoAtFaultCollisionDebugEvent * worst_event, const rclcpp::Time & timestamp)
+{
+  nlohmann::json objects = nlohmann::json::array();
+  std::set<std::string> seen_objects;
+  for (const auto & event : debug_info.events) {
+    if (!seen_objects.insert(event.object_id).second) {
+      continue;
+    }
+    objects.push_back(
+      {{"object_id", event.object_id},
+       {"label", event.object_label},
+       {"collision_type", event.collision_type},
+       {"first_collision_time_s", event.time_s}});
+  }
+
+  nlohmann::json events = nlohmann::json::array();
+  for (const auto & event : debug_info.events) {
+    auto event_json = nc_debug_event_to_json(event);
+    event_json["trajectory_stamp_sec"] = timestamp.seconds();
+    event_json["event_stamp_sec"] = timestamp.seconds() + event.time_s;
+    events.push_back(std::move(event_json));
+  }
+
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.no_at_fault_collision},
+    {"reason", metrics.no_at_fault_collision_reason},
+    {"worst_time_s", metrics.time_to_at_fault_collision_s},
+    {"worst_event_stamp_sec", std::isfinite(metrics.time_to_at_fault_collision_s)
+                                ? timestamp.seconds() + metrics.time_to_at_fault_collision_s
+                                : std::numeric_limits<double>::quiet_NaN()},
+    {"event_count", debug_info.events.size()},
+    {"at_fault_event_count", std::count_if(
+                               debug_info.events.begin(), debug_info.events.end(),
+                               [](const auto & event) { return event.at_fault; })},
+    {"worst_object_id", worst_event ? worst_event->object_id : "invalid"},
+    {"worst_object_label", worst_event ? worst_event->object_label : "UNKNOWN"},
+    {"worst_collision_type", worst_event ? worst_event->collision_type : "NONE"},
+    {"objects", std::move(objects)},
+    {"events", std::move(events)}};
+}
+
+nlohmann::json dac_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const DrivableAreaComplianceDebugInfo & debug_info,
+  const rclcpp::Time & timestamp)
+{
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.drivable_area_compliance},
+    {"reason", metrics.drivable_area_compliance_reason},
+    {"first_failure_time_s", debug_info.first_failure_time_s},
+    {"failure_stamp_sec", std::isfinite(debug_info.first_failure_time_s)
+                            ? timestamp.seconds() + debug_info.first_failure_time_s
+                            : std::numeric_limits<double>::quiet_NaN()},
+    {"failing_corner_indices", debug_info.failing_corner_indices},
+    {"corner_count_inside", debug_info.corner_count_inside},
+    {"route_candidate_count", debug_info.route_candidate_count},
+    {"road_candidate_count", debug_info.road_candidate_count},
+    {"shoulder_candidate_count", debug_info.shoulder_candidate_count},
+    {"intersection_candidate_count", debug_info.intersection_candidate_count},
+    {"hatched_road_marking_candidate_count", debug_info.hatched_road_marking_candidate_count},
+    {"road_border_line_count", debug_info.road_border_line_count},
+    {"road_border_fallback_used", debug_info.road_border_fallback_used},
+    {"road_border_side_test_count", debug_info.road_border_side_test_count},
+    {"road_border_side_accept_count", debug_info.road_border_side_accept_count},
+    {"parking_candidate_count", debug_info.parking_candidate_count}};
+}
+
+nlohmann::json ddc_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const DrivingDirectionComplianceDebugInfo & debug_info,
+  const rclcpp::Time & timestamp)
+{
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.driving_direction_compliance},
+    {"reason", metrics.driving_direction_compliance_reason},
+    {"max_oncoming_progress_m", metrics.max_oncoming_progress_m},
+    {"worst_window_start_s", debug_info.worst_window_start_time_s},
+    {"worst_window_end_s", debug_info.worst_window_end_time_s},
+    {"window_progress_m", debug_info.window_progress_m},
+    {"sample_count", debug_info.worst_window_sample_count}};
+}
+
+nlohmann::json tlc_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const TrafficLightComplianceDebugInfo & debug_info,
+  const rclcpp::Time & timestamp)
+{
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.traffic_light_compliance},
+    {"reason", metrics.traffic_light_compliance_reason},
+    {"first_failure_time_s", debug_info.first_failure_time_s},
+    {"failure_stamp_sec", std::isfinite(debug_info.first_failure_time_s)
+                            ? timestamp.seconds() + debug_info.first_failure_time_s
+                            : std::numeric_limits<double>::quiet_NaN()},
+    {"intended_movement",
+     debug_info.intended_movement.has_value() ? *debug_info.intended_movement : "unknown"},
+    {"regulatory_element_ids", debug_info.regulatory_element_ids},
+    {"selected_lane_ids", debug_info.selected_lane_ids},
+    {"stop_line_ids", debug_info.stop_line_ids},
+    {"selected_stop_line_count", debug_info.selected_stop_line_count}};
+}
+
+std::string ttc_area_condition_string(const TTCWithinBoundDebugEvent & event)
+{
+  if (event.ahead) {
+    return "ahead";
+  }
+  std::vector<std::string> conditions;
+  if (event.multiple_lanes) conditions.push_back("multiple_lanes");
+  if (event.non_drivable_area) conditions.push_back("non_drivable_area");
+  if (event.intersection) conditions.push_back("intersection");
+  if (conditions.empty()) {
+    return event.bad_or_intersection ? "bad_or_intersection" : "other";
+  }
+  return join_strings(conditions, "+");
+}
+
+nlohmann::json ttc_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const TTCWithinBoundDebugInfo & debug_info,
+  const rclcpp::Time & timestamp)
+{
+  nlohmann::json events = nlohmann::json::array();
+  for (const auto & event : debug_info.events) {
+    events.push_back(
+      {{"trajectory_stamp_sec", timestamp.seconds()},
+       {"event_stamp_sec", timestamp.seconds() + event.query_time_s},
+       {"time_s", event.time_s},
+       {"future_offset_s", event.future_offset_s},
+       {"query_time_s", event.query_time_s},
+       {"object_id", event.object_id},
+       {"object_label", event.object_label},
+       {"area_condition", ttc_area_condition_string(event)},
+       {"ahead", event.ahead},
+       {"behind", event.behind},
+       {"multiple_lanes", event.multiple_lanes},
+       {"non_drivable_area", event.non_drivable_area},
+       {"intersection", event.intersection},
+       {"bad_or_intersection", event.bad_or_intersection}});
+  }
+  const auto * event = debug_info.events.empty() ? nullptr : &debug_info.events.front();
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.time_to_collision_within_bound},
+    {"reason", metrics.time_to_collision_within_bound_reason},
+    {"first_failure_time_s", metrics.time_to_collision_infraction_time_s},
+    {"failure_stamp_sec", std::isfinite(metrics.time_to_collision_infraction_time_s)
+                            ? timestamp.seconds() + metrics.time_to_collision_infraction_time_s
+                            : std::numeric_limits<double>::quiet_NaN()},
+    {"future_offset_s", event ? event->future_offset_s : 0.0},
+    {"object_id", event ? event->object_id : "invalid"},
+    {"object_label", event ? event->object_label : "UNKNOWN"},
+    {"area_condition", event ? ttc_area_condition_string(*event) : "other"},
+    {"ahead", event ? event->ahead : false},
+    {"behind", event ? event->behind : false},
+    {"multiple_lanes", event ? event->multiple_lanes : false},
+    {"non_drivable_area", event ? event->non_drivable_area : false},
+    {"intersection", event ? event->intersection : false},
+    {"bad_or_intersection", event ? event->bad_or_intersection : false},
+    {"events", std::move(events)}};
+}
+
+nlohmann::json lk_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const LaneKeepingDebugInfo & debug_info,
+  const rclcpp::Time & timestamp)
+{
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.lane_keeping},
+    {"reason", metrics.lane_keeping_reason},
+    {"first_failure_time_s", debug_info.first_failure_time_s},
+    {"failure_run_start_s", debug_info.failure_run_start_time_s},
+    {"failure_run_end_s", debug_info.failure_run_end_time_s},
+    {"max_continuous_violation_time_s", debug_info.max_continuous_violation_time_s},
+    {"peak_abs_lateral_deviation_m", debug_info.peak_abs_lateral_deviation_m},
+    {"sample_count", debug_info.samples.size()}};
+}
+
+nlohmann::json ep_debug_summary_to_json(
+  const TrajectoryPointMetrics & metrics, const rclcpp::Time & timestamp)
+{
+  return nlohmann::json{
+    {"trajectory_stamp_sec", timestamp.seconds()},
+    {"score", metrics.ego_progress},
+    {"available", metrics.ego_progress_available},
+    {"reason", metrics.ego_progress_reason},
+    {"raw_progress_m", metrics.ego_progress_raw_m},
+    {"best_raw_progress_m", metrics.ego_progress_best_raw_m},
+    {"denominator_m", metrics.ego_progress_denominator_m},
+    {"multiplicative_mask", metrics.ego_progress_mask},
+    {"nc", metrics.no_at_fault_collision},
+    {"dac", metrics.drivable_area_compliance},
+    {"ddc", metrics.driving_direction_compliance},
+    {"tlc", metrics.traffic_light_compliance},
+    {"threshold_m", kEgoProgressDistanceThresholdM},
+    {"proposal_mode", "single_evaluated_trajectory"},
+    {"later_work",
+     "evaluate the full candidate proposal batch and compute candidate-level NC/DAC/DDC/TLC"}};
+}
+
+std_msgs::msg::ColorRGBA nc_horizon_footprint_color(
+  const NoAtFaultCollisionHorizonFootprint & footprint, const bool ego)
+{
+  if (footprint.at_fault) return make_color(1.0F, 0.05F, 0.05F, 1.0F);
+  if (footprint.collision) return make_color(1.0F, 0.8F, 0.0F, 1.0F);
+  return ego ? make_color(1.0F, 0.55F, 0.0F, 0.65F) : make_color(0.1F, 0.45F, 1.0F, 0.65F);
+}
+
+struct HCComponentStatus
+{
+  std::string name{"pass"};
+  double severity{0.0};
+};
+
+double threshold_ratio(const double value, const double threshold)
+{
+  if (threshold <= 0.0 || !std::isfinite(value)) return 0.0;
+  return std::abs(value) / threshold;
+}
+
+double longitudinal_acceleration_ratio(const double value, const HistoryComfortParameters & params)
+{
+  if (!std::isfinite(value)) {
+    return 0.0;
+  }
+  if (value > params.max_longitudinal_acceleration) {
+    return value / params.max_longitudinal_acceleration;
+  }
+  if (value < params.min_longitudinal_acceleration) {
+    return std::abs(value) / std::abs(params.min_longitudinal_acceleration);
+  }
+  return 0.0;
+}
+
+void consider_hc_component(HCComponentStatus & status, const std::string & name, const double ratio)
+{
+  if (ratio > status.severity) {
+    status.name = name;
+    status.severity = ratio;
+  }
+}
+
+HCComponentStatus hc_component_status_at(
+  const TrajectoryPointMetrics & metrics, const HistoryComfortParameters & params,
+  const std::size_t index)
+{
+  HCComponentStatus status;
+  if (index < metrics.longitudinal_accelerations.size()) {
+    consider_hc_component(
+      status, "ax",
+      longitudinal_acceleration_ratio(metrics.longitudinal_accelerations.at(index), params));
+  }
+  if (index < metrics.lateral_accelerations.size()) {
+    consider_hc_component(
+      status, "ay",
+      threshold_ratio(metrics.lateral_accelerations.at(index), params.max_lateral_acceleration));
+  }
+  if (index < metrics.jerk_magnitudes.size()) {
+    consider_hc_component(
+      status, "jerk",
+      threshold_ratio(metrics.jerk_magnitudes.at(index), params.max_jerk_magnitude));
+  }
+  if (index < metrics.longitudinal_jerks.size()) {
+    consider_hc_component(
+      status, "jx",
+      threshold_ratio(metrics.longitudinal_jerks.at(index), params.max_longitudinal_jerk));
+  }
+  if (index < metrics.yaw_rates.size()) {
+    consider_hc_component(
+      status, "yaw_rate", threshold_ratio(metrics.yaw_rates.at(index), params.max_yaw_rate));
+  }
+  if (index < metrics.yaw_accelerations.size()) {
+    consider_hc_component(
+      status, "yaw_accel",
+      threshold_ratio(metrics.yaw_accelerations.at(index), params.max_yaw_acceleration));
+  }
+  if (status.severity <= 1.0) {
+    status.name = "pass";
+  }
+  return status;
+}
+
+std_msgs::msg::ColorRGBA hc_component_color(const std::string & component, const bool peak)
+{
+  if (peak) {
+    return make_color(1.0F, 0.0F, 0.65F, 1.0F);
+  }
+  return component == "pass" ? make_color(1.0F, 0.55F, 0.0F, 0.45F)
+                             : make_color(1.0F, 0.05F, 0.05F, 0.95F);
+}
+
+}  // namespace
+
+void add_epdms_debug_result_topics(
+  std::vector<std::pair<std::string, std::string>> & topics,
+  const EpdmsDebugEnabledMetrics & enabled)
+{
+  add_marker_topic(topics, trajectory_debug_topic("planned_horizon_4s"));
+  add_marker_topic(topics, trajectory_debug_topic("gt_horizon_4s"));
+
+  if (enabled.no_at_fault_collision) {
+    add_string_topic(topics, debug_topic("nc", "collision_summary"));
+    add_marker_topic(topics, debug_topic("nc", "ego_footprints"));
+    add_marker_topic(topics, debug_topic("nc", "object_footprints"));
+    add_marker_topic(topics, debug_topic("nc", "overlap_areas"));
+  }
+  if (enabled.drivable_area_compliance) {
+    add_string_topic(topics, debug_topic("dac", "violation_summary"));
+    add_marker_topic(topics, debug_topic("dac", "ego_footprints"));
+    add_marker_topic(topics, debug_topic("dac", "admissible_road_areas"));
+    add_marker_topic(topics, debug_topic("dac", "admissible_shoulder_areas"));
+    add_marker_topic(topics, debug_topic("dac", "admissible_intersection_areas"));
+    add_marker_topic(topics, debug_topic("dac", "admissible_hatched_road_markings"));
+    add_marker_topic(topics, debug_topic("dac", "admissible_parking_areas"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_lines"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_side_test_segments"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_gap_segments"));
+    add_marker_topic(topics, debug_topic("dac", "semantic_boundary_points"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_closest_points"));
+    add_marker_topic(topics, debug_topic("dac", "corner_projection_points"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_plus_samples"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_minus_samples"));
+    add_marker_topic(topics, debug_topic("dac", "road_border_fallback_corners"));
+    add_marker_topic(topics, debug_topic("dac", "failing_corners"));
+  }
+  if (enabled.driving_direction_compliance) {
+    add_string_topic(topics, debug_topic("ddc", "violation_summary"));
+    add_marker_topic(topics, debug_topic("ddc", "ego_centers"));
+    add_marker_topic(topics, debug_topic("ddc", "oncoming_segments"));
+    add_marker_topic(topics, debug_topic("ddc", "route_lane_polygons"));
+    add_marker_topic(topics, debug_topic("ddc", "intersection_lane_polygons"));
+  }
+  if (enabled.traffic_light_compliance) {
+    add_string_topic(topics, debug_topic("tlc", "violation_summary"));
+    add_marker_topic(topics, debug_topic("tlc", "ego_footprints"));
+    add_marker_topic(topics, debug_topic("tlc", "stop_lines"));
+  }
+  if (enabled.time_to_collision_within_bound) {
+    add_string_topic(topics, debug_topic("ttc", "violation_summary"));
+    add_marker_topic(topics, debug_topic("ttc", "ego_footprints"));
+    add_marker_topic(topics, debug_topic("ttc", "object_footprints"));
+    add_marker_topic(topics, debug_topic("ttc", "overlap_areas"));
+  }
+  if (enabled.lane_keeping) {
+    add_string_topic(topics, debug_topic("lk", "violation_summary"));
+    add_marker_topic(topics, debug_topic("lk", "ego_center_path"));
+    add_marker_topic(topics, debug_topic("lk", "reference_centerlines"));
+  }
+  if (enabled.history_comfort) {
+    add_string_topic(topics, debug_topic("hc", "component_status"));
+    add_array_topic(topics, debug_topic("hc", "sample_times"));
+    add_array_topic(topics, debug_topic("hc", "segments"));
+    add_marker_topic(topics, debug_topic("hc", "horizon_footprints"));
+  }
+  if (enabled.extended_comfort) {
+    add_string_topic(topics, debug_topic("ec", "comparison_summary"));
+    add_array_topic(topics, debug_topic("ec", "sample_times"));
+    add_array_topic(topics, debug_topic("ec", "delta_acceleration"));
+    add_array_topic(topics, debug_topic("ec", "delta_jerk"));
+    add_array_topic(topics, debug_topic("ec", "delta_yaw_rate"));
+    add_array_topic(topics, debug_topic("ec", "delta_yaw_accel"));
+  }
+  if (enabled.ego_progress) {
+    add_string_topic(topics, debug_topic("ep", "progress_summary"));
+    add_marker_topic(topics, debug_topic("ep", "route_progress_points"));
+    add_marker_topic(topics, debug_topic("ep", "route_reference"));
+  }
+}
+
+void write_epdms_point_debug_topics_to_bag(
+  const TrajectoryPointMetrics & metrics, const EpdmsDebugEnabledMetrics & enabled,
+  const HistoryComfortParameters & history_comfort_params,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & timestamp)
+{
+  if (enabled.no_at_fault_collision && !metrics.no_at_fault_collision_debug.events.empty()) {
+    const auto & debug = metrics.no_at_fault_collision_debug;
+    const auto * worst_event = find_worst_nc_event(debug);
+    write_string(
+      nc_debug_summary_to_json(metrics, debug, worst_event, timestamp),
+      debug_topic("nc", "collision_summary"), bag_writer, timestamp);
+    MarkerArray ego_markers;
+    MarkerArray object_markers;
+    MarkerArray overlap_markers;
+    ego_markers.markers.push_back(make_delete_all_marker(timestamp));
+    object_markers.markers.push_back(make_delete_all_marker(timestamp));
+    overlap_markers.markers.push_back(make_delete_all_marker(timestamp));
+    int marker_id = 0;
+    for (const auto & footprint : debug.ego_horizon_footprints) {
+      const double width = footprint.collision ? 0.28 : 0.12;
+      ego_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "nc_horizon_ego_footprints", marker_id++, footprint.footprint,
+        nc_horizon_footprint_color(footprint, true), width, true, kDebugMarkerLifetimeS, 0.12));
+    }
+    marker_id = 0;
+    for (const auto & footprint : debug.object_horizon_footprints) {
+      const double width = footprint.collision ? 0.28 : 0.12;
+      object_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "nc_horizon_object_footprints", marker_id++, footprint.footprint,
+        nc_horizon_footprint_color(footprint, false), width, true, kDebugMarkerLifetimeS, 0.18));
+    }
+    marker_id = 0;
+    for (const auto & overlap : debug.overlap_areas) {
+      overlap_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "nc_horizon_overlap_areas", marker_id++, overlap.polygon,
+        overlap.at_fault ? make_color(1.0F, 0.0F, 0.8F, 1.0F) : make_color(1.0F, 0.6F, 0.0F, 1.0F),
+        overlap.at_fault ? 0.6 : 0.4, true, kDebugMarkerLifetimeS, 0.28));
+    }
+    bag_writer.write(ego_markers, debug_topic("nc", "ego_footprints"), timestamp);
+    bag_writer.write(object_markers, debug_topic("nc", "object_footprints"), timestamp);
+    bag_writer.write(overlap_markers, debug_topic("nc", "overlap_areas"), timestamp);
+  }
+
+  if (
+    enabled.drivable_area_compliance && metrics.drivable_area_compliance_available &&
+    metrics.drivable_area_compliance < 1.0) {
+    const auto & debug = metrics.drivable_area_compliance_debug;
+    if (std::isfinite(debug.first_failure_time_s)) {
+      write_string(
+        dac_debug_summary_to_json(metrics, debug, timestamp),
+        debug_topic("dac", "violation_summary"), bag_writer, timestamp);
+    }
+    MarkerArray ego_markers;
+    ego_markers.markers.push_back(make_delete_all_marker(timestamp));
+    int marker_id = 0;
+    for (const auto & footprint : debug.ego_horizon_footprints) {
+      ego_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "dac_horizon_ego_footprints", marker_id++, footprint.footprint,
+        footprint.non_drivable_area ? make_color(1.0F, 0.05F, 0.05F, 1.0F)
+                                    : make_color(1.0F, 0.55F, 0.0F, 0.6F),
+        footprint.non_drivable_area ? 0.22 : 0.12, true, kDebugMarkerLifetimeS, 0.10));
+    }
+    bag_writer.write(ego_markers, debug_topic("dac", "ego_footprints"), timestamp);
+    const auto write_polygons = [&](
+                                  const auto & polygons, const std::string & name,
+                                  const std_msgs::msg::ColorRGBA & marker_color, const double width,
+                                  const bool close_line, const double z_offset) {
+      MarkerArray markers;
+      markers.markers.push_back(make_delete_all_marker(timestamp));
+      int id = 0;
+      for (const auto & polygon : polygons) {
+        markers.markers.push_back(make_line_strip_marker(
+          timestamp, "dac_horizon_" + name, id++, polygon.polygon, marker_color, width, close_line,
+          kDebugMarkerLifetimeS, z_offset));
+      }
+      bag_writer.write(markers, debug_topic("dac", name), timestamp);
+    };
+    write_polygons(
+      debug.admissible_road_areas, "admissible_road_areas", make_color(0.0F, 0.9F, 1.0F, 0.8F),
+      0.12, true, 0.02);
+    write_polygons(
+      debug.admissible_shoulder_areas, "admissible_shoulder_areas",
+      make_color(0.95F, 0.75F, 0.2F, 0.85F), 0.12, true, 0.03);
+    write_polygons(
+      debug.admissible_intersection_areas, "admissible_intersection_areas",
+      make_color(0.45F, 0.65F, 1.0F, 0.85F), 0.12, true, 0.04);
+    write_polygons(
+      debug.admissible_hatched_road_markings, "admissible_hatched_road_markings",
+      make_color(1.0F, 0.55F, 0.05F, 0.85F), 0.12, true, 0.05);
+    write_polygons(
+      debug.admissible_parking_areas, "admissible_parking_areas",
+      make_color(0.2F, 1.0F, 0.4F, 0.8F), 0.12, true, 0.06);
+    write_polygons(
+      debug.road_border_lines, "road_border_lines", make_color(0.75F, 0.15F, 1.0F, 0.95F), 0.10,
+      false, 0.08);
+    write_polygons(
+      debug.road_border_side_test_segments, "road_border_side_test_segments",
+      make_color(1.0F, 1.0F, 1.0F, 0.95F), 0.18, false, 0.12);
+    write_polygons(
+      debug.road_border_gap_segments, "road_border_gap_segments",
+      make_color(1.0F, 0.85F, 0.05F, 0.95F), 0.16, false, 0.11);
+    const auto write_points = [&](
+                                const auto & points, const std::string & name,
+                                const std_msgs::msg::ColorRGBA & marker_color,
+                                const double half_extent, const double width,
+                                const double z_offset) {
+      MarkerArray markers;
+      markers.markers.push_back(make_delete_all_marker(timestamp));
+      int id = 0;
+      for (const auto & point : points) {
+        markers.markers.push_back(make_line_strip_marker(
+          timestamp, "dac_horizon_" + name, id++, square_marker_points(point.point, half_extent),
+          marker_color, width, false, kDebugMarkerLifetimeS, z_offset));
+      }
+      bag_writer.write(markers, debug_topic("dac", name), timestamp);
+    };
+    write_points(
+      debug.semantic_boundary_points, "semantic_boundary_points",
+      make_color(1.0F, 0.85F, 0.05F, 1.0F), 0.12, 0.10, 0.13);
+    write_points(
+      debug.road_border_closest_points, "road_border_closest_points",
+      make_color(0.75F, 0.15F, 1.0F, 1.0F), 0.12, 0.10, 0.14);
+    write_points(
+      debug.corner_projection_points, "corner_projection_points",
+      make_color(1.0F, 1.0F, 1.0F, 1.0F), 0.10, 0.08, 0.15);
+    write_points(
+      debug.road_border_plus_samples, "road_border_plus_samples",
+      make_color(0.1F, 0.45F, 1.0F, 1.0F), 0.12, 0.10, 0.13);
+    write_points(
+      debug.road_border_minus_samples, "road_border_minus_samples",
+      make_color(0.15F, 1.0F, 0.35F, 1.0F), 0.12, 0.10, 0.14);
+    write_points(
+      debug.road_border_fallback_corners, "road_border_fallback_corners",
+      make_color(0.75F, 0.15F, 1.0F, 1.0F), 0.14, 0.12, 0.17);
+    write_points(
+      debug.failing_corners, "failing_corners", make_color(1.0F, 0.0F, 0.8F, 1.0F), 0.18, 0.16,
+      0.16);
+  }
+
+  if (
+    enabled.driving_direction_compliance && metrics.driving_direction_compliance_available &&
+    metrics.driving_direction_compliance < 1.0 &&
+    !metrics.driving_direction_compliance_debug.samples.empty()) {
+    const auto & debug = metrics.driving_direction_compliance_debug;
+    write_string(
+      ddc_debug_summary_to_json(metrics, debug, timestamp), debug_topic("ddc", "violation_summary"),
+      bag_writer, timestamp);
+    MarkerArray centers;
+    MarkerArray segments;
+    centers.markers.push_back(make_delete_all_marker(timestamp));
+    segments.markers.push_back(make_delete_all_marker(timestamp));
+    std::vector<geometry_msgs::msg::Point> center_points;
+    center_points.reserve(debug.samples.size());
+    int marker_id = 0;
+    for (std::size_t index = 0; index < debug.samples.size(); ++index) {
+      const auto & sample = debug.samples.at(index);
+      center_points.push_back(sample.ego_center);
+      if (index == 0U || sample.counted_progress_m <= 0.0) {
+        continue;
+      }
+      segments.markers.push_back(make_line_strip_marker(
+        timestamp, "ddc_oncoming_segments", marker_id++,
+        {debug.samples.at(index - 1U).ego_center, sample.ego_center},
+        make_color(1.0F, 0.05F, 0.05F, 1.0F), 0.18, false, kDebugMarkerLifetimeS, 0.12));
+    }
+    if (center_points.size() >= 2U) {
+      centers.markers.push_back(make_line_strip_marker(
+        timestamp, "ddc_ego_centers", 0, center_points, make_color(1.0F, 0.55F, 0.0F, 0.8F), 0.12,
+        false, kDebugMarkerLifetimeS, 0.08));
+    }
+    bag_writer.write(centers, debug_topic("ddc", "ego_centers"), timestamp);
+    bag_writer.write(segments, debug_topic("ddc", "oncoming_segments"), timestamp);
+    const auto write_ddc_polygons = [&](
+                                      const auto & polygons, const std::string & name,
+                                      const std_msgs::msg::ColorRGBA & marker_color,
+                                      const double width, const double z_offset) {
+      MarkerArray markers;
+      markers.markers.push_back(make_delete_all_marker(timestamp));
+      int id = 0;
+      for (const auto & polygon : polygons) {
+        markers.markers.push_back(make_line_strip_marker(
+          timestamp, "ddc_" + name, id++, polygon.polygon, marker_color, width, true,
+          kDebugMarkerLifetimeS, z_offset));
+      }
+      bag_writer.write(markers, debug_topic("ddc", name), timestamp);
+    };
+    write_ddc_polygons(
+      debug.route_lane_polygons, "route_lane_polygons", make_color(0.0F, 0.9F, 1.0F, 0.85F), 0.18,
+      0.16);
+    write_ddc_polygons(
+      debug.intersection_lane_polygons, "intersection_lane_polygons",
+      make_color(0.2F, 1.0F, 0.4F, 0.90F), 0.20, 0.22);
+  }
+
+  if (
+    enabled.traffic_light_compliance && metrics.traffic_light_compliance_available &&
+    metrics.traffic_light_compliance < 1.0) {
+    const auto & debug = metrics.traffic_light_compliance_debug;
+    if (std::isfinite(debug.first_failure_time_s)) {
+      write_string(
+        tlc_debug_summary_to_json(metrics, debug, timestamp),
+        debug_topic("tlc", "violation_summary"), bag_writer, timestamp);
+    }
+    MarkerArray ego_markers;
+    MarkerArray stop_line_markers;
+    ego_markers.markers.push_back(make_delete_all_marker(timestamp));
+    stop_line_markers.markers.push_back(make_delete_all_marker(timestamp));
+    int marker_id = 0;
+    for (const auto & footprint : debug.ego_horizon_footprints) {
+      const bool failed = footprint.time_s + 1.0e-3 >= debug.first_failure_time_s;
+      ego_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "tlc_ego_footprints", marker_id++, footprint.polygon,
+        failed ? make_color(1.0F, 0.05F, 0.05F, 1.0F) : make_color(1.0F, 0.55F, 0.0F, 0.60F),
+        failed ? 0.22 : 0.12, true, kDebugMarkerLifetimeS, 0.12));
+    }
+    marker_id = 0;
+    for (const auto & line : debug.stop_lines) {
+      stop_line_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "tlc_stop_lines", marker_id++, line.polygon,
+        make_color(1.0F, 0.05F, 0.05F, 0.95F), 0.18, false, kDebugMarkerLifetimeS, 0.28));
+    }
+    bag_writer.write(ego_markers, debug_topic("tlc", "ego_footprints"), timestamp);
+    bag_writer.write(stop_line_markers, debug_topic("tlc", "stop_lines"), timestamp);
+  }
+
+  if (
+    enabled.time_to_collision_within_bound && metrics.time_to_collision_within_bound_available &&
+    metrics.time_to_collision_within_bound < 1.0 &&
+    !metrics.time_to_collision_within_bound_debug.events.empty()) {
+    const auto & debug = metrics.time_to_collision_within_bound_debug;
+    write_string(
+      ttc_debug_summary_to_json(metrics, debug, timestamp), debug_topic("ttc", "violation_summary"),
+      bag_writer, timestamp);
+    MarkerArray ego_markers;
+    MarkerArray object_markers;
+    MarkerArray overlap_markers;
+    ego_markers.markers.push_back(make_delete_all_marker(timestamp));
+    object_markers.markers.push_back(make_delete_all_marker(timestamp));
+    overlap_markers.markers.push_back(make_delete_all_marker(timestamp));
+    int marker_id = 0;
+    for (const auto & footprint : debug.ego_horizon_footprints) {
+      const bool prefix = footprint.prefix;
+      const double width = prefix ? 0.08 : (footprint.overlap ? 0.28 : 0.12);
+      const auto marker_color = prefix
+                                  ? make_color(1.0F, 0.55F, 0.0F, 0.28F)
+                                  : (footprint.overlap ? make_color(1.0F, 0.05F, 0.05F, 1.0F)
+                                                       : make_color(0.95F, 0.28F, 0.0F, 0.88F));
+      ego_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "ttc_ego_footprints", marker_id++, footprint.footprint, marker_color, width,
+        true, kDebugMarkerLifetimeS, 0.12));
+    }
+    marker_id = 0;
+    for (const auto & footprint : debug.object_horizon_footprints) {
+      const bool prefix = footprint.prefix;
+      const double width = prefix ? 0.08 : (footprint.overlap ? 0.28 : 0.12);
+      const auto marker_color = prefix
+                                  ? make_color(0.1F, 0.45F, 1.0F, 0.28F)
+                                  : (footprint.overlap ? make_color(1.0F, 0.05F, 0.05F, 1.0F)
+                                                       : make_color(0.02F, 0.12F, 0.70F, 0.88F));
+      object_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "ttc_object_footprints", marker_id++, footprint.footprint, marker_color, width,
+        true, kDebugMarkerLifetimeS, 0.18));
+    }
+    marker_id = 0;
+    for (const auto & overlap : debug.overlap_areas) {
+      overlap_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "ttc_overlap_areas", marker_id++, overlap.polygon,
+        make_color(1.0F, 0.0F, 0.8F, 1.0F), 0.40, true, kDebugMarkerLifetimeS, 0.24));
+    }
+    bag_writer.write(ego_markers, debug_topic("ttc", "ego_footprints"), timestamp);
+    bag_writer.write(object_markers, debug_topic("ttc", "object_footprints"), timestamp);
+    bag_writer.write(overlap_markers, debug_topic("ttc", "overlap_areas"), timestamp);
+  }
+
+  if (
+    enabled.lane_keeping && metrics.lane_keeping_available && metrics.lane_keeping < 1.0 &&
+    !metrics.lane_keeping_debug.samples.empty()) {
+    const auto & debug = metrics.lane_keeping_debug;
+    write_string(
+      lk_debug_summary_to_json(metrics, debug, timestamp), debug_topic("lk", "violation_summary"),
+      bag_writer, timestamp);
+    MarkerArray path_markers;
+    MarkerArray centerline_markers;
+    path_markers.markers.push_back(make_delete_all_marker(timestamp));
+    centerline_markers.markers.push_back(make_delete_all_marker(timestamp));
+    int marker_id = 0;
+    for (std::size_t index = 1; index < debug.samples.size(); ++index) {
+      const auto & previous = debug.samples.at(index - 1U);
+      const auto & sample = debug.samples.at(index);
+      const bool violating = sample.over_threshold && !sample.is_in_intersection;
+      const auto marker_color = sample.in_failure_run       ? make_color(1.0F, 0.12F, 0.12F, 1.0F)
+                                : sample.is_in_intersection ? make_color(0.2F, 1.0F, 0.4F, 0.95F)
+                                : violating                 ? make_color(1.0F, 0.65F, 0.0F, 0.95F)
+                                                            : make_color(1.0F, 0.55F, 0.0F, 0.85F);
+      const double width = sample.in_failure_run ? 0.18 : 0.12;
+      path_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "lk_ego_center_path", marker_id++, {previous.ego_center, sample.ego_center},
+        marker_color, width, false, kDebugMarkerLifetimeS, 0.08));
+    }
+    std::set<std::int64_t> seen_lanelet_ids;
+    marker_id = 0;
+    for (const auto & sample : debug.samples) {
+      if (sample.reference_centerline.size() < 2U || sample.reference_lanelet_id < 0) {
+        continue;
+      }
+      if (!seen_lanelet_ids.insert(sample.reference_lanelet_id).second) {
+        continue;
+      }
+      centerline_markers.markers.push_back(make_line_strip_marker(
+        timestamp, "lk_reference_centerlines", marker_id++, sample.reference_centerline,
+        make_color(0.2F, 1.0F, 0.4F, 0.80F), 0.08, false, kDebugMarkerLifetimeS, 0.12));
+    }
+    bag_writer.write(path_markers, debug_topic("lk", "ego_center_path"), timestamp);
+    bag_writer.write(centerline_markers, debug_topic("lk", "reference_centerlines"), timestamp);
+  }
+
+  if (enabled.history_comfort && !metrics.history_comfort_sample_times.empty()) {
+    std_msgs::msg::String summary_msg;
+    summary_msg.data = metrics.history_comfort_debug_summary;
+    bag_writer.write(summary_msg, debug_topic("hc", "component_status"), timestamp);
+    write_array(
+      metrics.history_comfort_sample_times, debug_topic("hc", "sample_times"), bag_writer,
+      timestamp);
+    write_array(
+      metrics.history_comfort_segment_ids, debug_topic("hc", "segments"), bag_writer, timestamp);
+    MarkerArray markers;
+    markers.markers.push_back(make_delete_all_marker(timestamp));
+    const auto local_footprint = vehicle_info.createFootprint(0.0);
+    std::vector<HCComponentStatus> statuses;
+    statuses.reserve(metrics.history_comfort_sample_poses.size());
+    std::size_t peak_index = 0U;
+    double peak_severity = 0.0;
+    for (std::size_t index = 0; index < metrics.history_comfort_sample_poses.size(); ++index) {
+      auto status = hc_component_status_at(metrics, history_comfort_params, index);
+      if (status.severity > peak_severity) {
+        peak_severity = status.severity;
+        peak_index = index;
+      }
+      statuses.push_back(std::move(status));
+    }
+    int marker_id = 0;
+    for (std::size_t index = 0; index < metrics.history_comfort_sample_poses.size(); ++index) {
+      const auto & pose = metrics.history_comfort_sample_poses.at(index);
+      const auto footprint = create_pose_footprint(pose, local_footprint);
+      const bool peak = peak_severity > 1.0 && index == peak_index;
+      const auto & status = statuses.at(index);
+      const bool failed = status.severity > 1.0;
+      const double width = peak ? 0.34 : (failed ? 0.22 : 0.10);
+      const double z_offset = peak ? 0.24 : (failed ? 0.16 : 0.08);
+      markers.markers.push_back(make_line_strip_marker(
+        timestamp, "hc_horizon_footprints", marker_id++,
+        polygon_to_points(footprint, pose.position.z), hc_component_color(status.name, peak), width,
+        true, kDebugMarkerLifetimeS, z_offset));
+    }
+    bag_writer.write(markers, debug_topic("hc", "horizon_footprints"), timestamp);
+  }
+
+  if (enabled.ego_progress) {
+    write_string(
+      ep_debug_summary_to_json(metrics, timestamp), debug_topic("ep", "progress_summary"),
+      bag_writer, timestamp);
+    MarkerArray route_points;
+    route_points.markers.push_back(make_delete_all_marker(timestamp));
+    route_points.markers.push_back(make_line_strip_marker(
+      timestamp, "ep_start_point", 0, square_marker_points(metrics.ego_progress_start_point, 0.35),
+      make_color(0.1F, 0.9F, 1.0F, 1.0F), 0.18, true, kDebugMarkerLifetimeS, 0.22));
+    route_points.markers.push_back(make_line_strip_marker(
+      timestamp, "ep_end_point", 1, square_marker_points(metrics.ego_progress_end_point, 0.35),
+      make_color(0.0F, 1.0F, 0.35F, 1.0F), 0.18, true, kDebugMarkerLifetimeS, 0.24));
+    route_points.markers.push_back(make_line_strip_marker(
+      timestamp, "ep_progress_chord", 2,
+      {metrics.ego_progress_start_point, metrics.ego_progress_end_point},
+      make_color(0.0F, 0.8F, 1.0F, 0.9F), 0.16, false, kDebugMarkerLifetimeS, 0.20));
+    MarkerArray route_reference;
+    route_reference.markers.push_back(make_delete_all_marker(timestamp));
+    if (metrics.ego_progress_route_reference_points.size() >= 2U) {
+      route_reference.markers.push_back(make_line_strip_marker(
+        timestamp, "ep_route_reference", 0, metrics.ego_progress_route_reference_points,
+        make_color(1.0F, 0.85F, 0.15F, 0.85F), 0.12, false, kDebugMarkerLifetimeS, 0.14));
+    }
+    bag_writer.write(route_points, debug_topic("ep", "route_progress_points"), timestamp);
+    bag_writer.write(route_reference, debug_topic("ep", "route_reference"), timestamp);
+  }
+}
+
+void write_epdms_extended_comfort_debug_topics_to_bag(
+  const std::string & summary, const std::vector<double> & sample_times,
+  const std::vector<double> & delta_acceleration, const std::vector<double> & delta_jerk,
+  const std::vector<double> & delta_yaw_rate, const std::vector<double> & delta_yaw_accel,
+  rosbag2_cpp::Writer & bag_writer, const rclcpp::Time & timestamp)
+{
+  if (summary.empty()) {
+    return;
+  }
+  std_msgs::msg::String summary_msg;
+  summary_msg.data = summary;
+  bag_writer.write(summary_msg, debug_topic("ec", "comparison_summary"), timestamp);
+  write_array(sample_times, debug_topic("ec", "sample_times"), bag_writer, timestamp);
+  write_array(delta_acceleration, debug_topic("ec", "delta_acceleration"), bag_writer, timestamp);
+  write_array(delta_jerk, debug_topic("ec", "delta_jerk"), bag_writer, timestamp);
+  write_array(delta_yaw_rate, debug_topic("ec", "delta_yaw_rate"), bag_writer, timestamp);
+  write_array(delta_yaw_accel, debug_topic("ec", "delta_yaw_accel"), bag_writer, timestamp);
+}
+
+void write_epdms_trajectory_horizon_debug_topics_to_bag(
+  const autoware_planning_msgs::msg::Trajectory & planned_trajectory,
+  const autoware_planning_msgs::msg::Trajectory & ground_truth_trajectory,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & timestamp)
+{
+  constexpr double kDebugHorizonSeconds = 4.0;
+  const auto local_footprint = vehicle_info.createFootprint(0.0);
+  const auto planned_horizon =
+    truncate_trajectory_by_horizon(planned_trajectory, kDebugHorizonSeconds);
+  const auto gt_horizon =
+    truncate_trajectory_by_horizon(ground_truth_trajectory, kDebugHorizonSeconds);
+
+  MarkerArray planned_markers;
+  MarkerArray gt_markers;
+  planned_markers.markers.push_back(make_delete_all_marker(timestamp));
+  gt_markers.markers.push_back(make_delete_all_marker(timestamp));
+
+  int32_t marker_id = 0;
+  for (const auto & point : planned_horizon.points) {
+    const auto footprint = create_pose_footprint(point.pose, local_footprint);
+    planned_markers.markers.push_back(make_filled_polygon_marker(
+      timestamp, "trajectory_planned_horizon_4s", marker_id++,
+      polygon_to_points(footprint, point.pose.position.z + 0.04),
+      make_color(1.0F, 0.55F, 0.0F, 0.35F), kDebugMarkerLifetimeS, 0.0));
+  }
+
+  marker_id = 0;
+  for (const auto & point : gt_horizon.points) {
+    const auto footprint = create_pose_footprint(point.pose, local_footprint);
+    gt_markers.markers.push_back(make_filled_polygon_marker(
+      timestamp, "trajectory_gt_horizon_4s", marker_id++,
+      polygon_to_points(footprint, point.pose.position.z + 0.08),
+      make_color(0.2F, 1.0F, 0.4F, 0.35F), kDebugMarkerLifetimeS, 0.0));
+  }
+
+  bag_writer.write(planned_markers, trajectory_debug_topic("planned_horizon_4s"), timestamp);
+  bag_writer.write(gt_markers, trajectory_debug_topic("gt_horizon_4s"), timestamp);
+}
+
+}  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/debug/epdms_debug_writer.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/debug/epdms_debug_writer.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef METRICS__EPDMS__DEBUG__EPDMS_DEBUG_WRITER_HPP_
+#define METRICS__EPDMS__DEBUG__EPDMS_DEBUG_WRITER_HPP_
+
+#include "metrics/trajectory_metrics.hpp"
+
+#include <autoware_vehicle_info_utils/vehicle_info.hpp>
+#include <rclcpp/time.hpp>
+#include <rosbag2_cpp/writer.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics
+{
+
+struct EpdmsDebugEnabledMetrics
+{
+  bool history_comfort{false};
+  bool extended_comfort{false};
+  bool time_to_collision_within_bound{false};
+  bool lane_keeping{false};
+  bool ego_progress{false};
+  bool drivable_area_compliance{false};
+  bool no_at_fault_collision{false};
+  bool driving_direction_compliance{false};
+  bool traffic_light_compliance{false};
+};
+
+void add_epdms_debug_result_topics(
+  std::vector<std::pair<std::string, std::string>> & topics,
+  const EpdmsDebugEnabledMetrics & enabled);
+
+void write_epdms_point_debug_topics_to_bag(
+  const TrajectoryPointMetrics & metrics, const EpdmsDebugEnabledMetrics & enabled,
+  const HistoryComfortParameters & history_comfort_params,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & timestamp);
+
+void write_epdms_extended_comfort_debug_topics_to_bag(
+  const std::string & summary, const std::vector<double> & sample_times,
+  const std::vector<double> & delta_acceleration, const std::vector<double> & delta_jerk,
+  const std::vector<double> & delta_yaw_rate, const std::vector<double> & delta_yaw_accel,
+  rosbag2_cpp::Writer & bag_writer, const rclcpp::Time & timestamp);
+
+void write_epdms_trajectory_horizon_debug_topics_to_bag(
+  const autoware_planning_msgs::msg::Trajectory & planned_trajectory,
+  const autoware_planning_msgs::msg::Trajectory & ground_truth_trajectory,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, rosbag2_cpp::Writer & bag_writer,
+  const rclcpp::Time & timestamp);
+
+}  // namespace autoware::planning_data_analyzer::metrics
+
+#endif  // METRICS__EPDMS__DEBUG__EPDMS_DEBUG_WRITER_HPP_

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
@@ -224,7 +224,8 @@ DrivableAreaComplianceResult calculate_drivable_area_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations)
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations,
+  const bool collect_debug)
 {
   DrivableAreaComplianceResult result;
   if (trajectory.points.empty()) {
@@ -270,7 +271,9 @@ DrivableAreaComplianceResult calculate_drivable_area_compliance(
     }
   }
 
-  fill_debug_info(result.debug_info, trajectory, evaluations);
+  if (collect_debug) {
+    fill_debug_info(result.debug_info, trajectory, evaluations);
+  }
 
   for (const auto & evaluation : evaluations) {
     if (evaluation.ego_area_evaluation->flags.non_drivable_area) {

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.hpp
@@ -98,7 +98,8 @@ DrivableAreaComplianceResult calculate_drivable_area_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr);
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr,
+  bool collect_debug = false);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/driving_direction_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/driving_direction_compliance.cpp
@@ -46,13 +46,22 @@ DrivingDirectionComplianceResult calculate_driving_direction_compliance(
   for (size_t i = 0; i < evaluation_points.size(); ++i) {
     const double t_i = evaluation_points.at(i).time_from_start_s;
     double horizon_sum = 0.0;
+    std::size_t horizon_count = 0U;
+    double horizon_start_time_s = t_i;
     for (size_t j = 0; j <= i; ++j) {
       const double t_j = evaluation_points.at(j).time_from_start_s;
       if (t_i - t_j <= params.horizon_s + 1.0e-6) {
         horizon_sum += filtered_progress[j];
+        ++horizon_count;
+        horizon_start_time_s = std::min(horizon_start_time_s, t_j);
       }
     }
-    result.max_oncoming_progress_m = std::max(result.max_oncoming_progress_m, horizon_sum);
+    if (horizon_sum > result.max_oncoming_progress_m) {
+      result.max_oncoming_progress_m = horizon_sum;
+      result.worst_window_start_time_s = horizon_start_time_s;
+      result.worst_window_end_time_s = t_i;
+      result.worst_window_sample_count = horizon_count;
+    }
   }
 
   if (result.max_oncoming_progress_m < params.compliance_threshold_m) {

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/driving_direction_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/driving_direction_compliance.hpp
@@ -15,6 +15,9 @@
 #ifndef METRICS__EPDMS__SUBSCORES__DRIVING_DIRECTION_COMPLIANCE_HPP_
 #define METRICS__EPDMS__SUBSCORES__DRIVING_DIRECTION_COMPLIANCE_HPP_
 
+#include <geometry_msgs/msg/point.hpp>
+
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <vector>
@@ -43,6 +46,38 @@ struct DrivingDirectionComplianceResult
   bool available{false};
   std::string reason{"unavailable"};
   double max_oncoming_progress_m{0.0};
+  double worst_window_start_time_s{0.0};
+  double worst_window_end_time_s{0.0};
+  std::size_t worst_window_sample_count{0U};
+};
+
+struct DrivingDirectionDebugPolygon
+{
+  double time_s{0.0};
+  std::vector<geometry_msgs::msg::Point> polygon;
+};
+
+struct DrivingDirectionDebugSample
+{
+  double time_s{0.0};
+  double progress_m{0.0};
+  double counted_progress_m{0.0};
+  bool in_oncoming_traffic{false};
+  bool in_lane_margin_only{false};
+  bool is_intersection{false};
+  geometry_msgs::msg::Point ego_center;
+};
+
+struct DrivingDirectionComplianceDebugInfo
+{
+  double worst_window_start_time_s{0.0};
+  double worst_window_end_time_s{0.0};
+  std::size_t worst_window_sample_count{0U};
+  double window_progress_m{0.0};
+  geometry_msgs::msg::Point label_anchor;
+  std::vector<DrivingDirectionDebugSample> samples;
+  std::vector<DrivingDirectionDebugPolygon> route_lane_polygons;
+  std::vector<DrivingDirectionDebugPolygon> intersection_lane_polygons;
 };
 
 DrivingDirectionComplianceResult calculate_driving_direction_compliance(

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
@@ -118,8 +118,7 @@ EgoProgressResult calculate_ego_progress(
   result.denominator_m = result.raw_progress_m * result.multiplicative_mask;
   result.available = true;
 
-  constexpr double kProgressDistanceThresholdM = 5.0;
-  if (result.denominator_m > kProgressDistanceThresholdM) {
+  if (result.denominator_m > kEgoProgressDistanceThresholdM) {
     // Note: Since we only have a single trajectory candidate in this implementation,
     // the score simplifies to 1.0 (raw_progress / denominator where denominator = raw_progress
     // * 1.0) if all multiplicative metrics passed.

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.hpp
@@ -31,6 +31,8 @@ namespace autoware::planning_data_analyzer::metrics
 
 using autoware::route_handler::RouteHandler;
 
+inline constexpr double kEgoProgressDistanceThresholdM = 5.0;
+
 struct EgoProgressResult
 {
   double score{0.0};

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <sstream>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -62,19 +63,28 @@ std::vector<ComfortSignalInput> make_overlap_signal_inputs(
   return inputs;
 }
 
-double rms_difference(const std::vector<double> & current, const std::vector<double> & previous)
+std::vector<double> subtract_signals(
+  const std::vector<double> & current, const std::vector<double> & previous)
 {
   const auto count = std::min(current.size(), previous.size());
-  if (count == 0U) {
+  std::vector<double> delta;
+  delta.reserve(count);
+  for (std::size_t index = 0; index < count; ++index) {
+    delta.push_back(current.at(index) - previous.at(index));
+  }
+  return delta;
+}
+
+double rms(const std::vector<double> & values)
+{
+  if (values.empty()) {
     return 0.0;
   }
-
   double sum_squared = 0.0;
-  for (std::size_t index = 0; index < count; ++index) {
-    const double delta = current[index] - previous[index];
-    sum_squared += delta * delta;
+  for (const auto value : values) {
+    sum_squared += value * value;
   }
-  return std::sqrt(sum_squared / static_cast<double>(count));
+  return std::sqrt(sum_squared / static_cast<double>(values.size()));
 }
 
 bool are_parameters_valid(const ExtendedComfortParameters & parameters)
@@ -124,6 +134,10 @@ ExtendedComfortResult calculate_extended_comfort(
     result.reason = "unavailable_short_overlap";
     return result;
   }
+  result.sample_times.reserve(overlap_count);
+  for (std::size_t index = 0; index < overlap_count; ++index) {
+    result.sample_times.push_back(static_cast<double>(index) * dt);
+  }
 
   const auto current_inputs = make_overlap_signal_inputs(current_trajectory, 0U, overlap_count);
   const auto previous_inputs =
@@ -131,13 +145,18 @@ ExtendedComfortResult calculate_extended_comfort(
   const auto current_signals = compute_comfort_signals(current_inputs);
   const auto previous_signals = compute_comfort_signals(previous_inputs);
 
-  const double acceleration_rms = rms_difference(
+  result.delta_acceleration = subtract_signals(
     current_signals.acceleration_magnitudes, previous_signals.acceleration_magnitudes);
-  const double jerk_rms =
-    rms_difference(current_signals.jerk_magnitudes, previous_signals.jerk_magnitudes);
-  const double yaw_rate_rms = rms_difference(current_signals.yaw_rates, previous_signals.yaw_rates);
-  const double yaw_acceleration_rms =
-    rms_difference(current_signals.yaw_accelerations, previous_signals.yaw_accelerations);
+  result.delta_jerk =
+    subtract_signals(current_signals.jerk_magnitudes, previous_signals.jerk_magnitudes);
+  result.delta_yaw_rate = subtract_signals(current_signals.yaw_rates, previous_signals.yaw_rates);
+  result.delta_yaw_accel =
+    subtract_signals(current_signals.yaw_accelerations, previous_signals.yaw_accelerations);
+
+  const double acceleration_rms = rms(result.delta_acceleration);
+  const double jerk_rms = rms(result.delta_jerk);
+  const double yaw_rate_rms = rms(result.delta_yaw_rate);
+  const double yaw_acceleration_rms = rms(result.delta_yaw_accel);
 
   const bool acceleration_ok = acceleration_rms <= parameters.max_acceleration_rms;
   const bool jerk_ok = jerk_rms <= parameters.max_jerk_rms;
@@ -147,6 +166,12 @@ ExtendedComfortResult calculate_extended_comfort(
   result.available = true;
   result.reason = "available";
   result.score = acceleration_ok && jerk_ok && yaw_rate_ok && yaw_acceleration_ok ? 1.0 : 0.0;
+  std::ostringstream summary;
+  summary << "{\"score\":" << result.score << ",\"reason\":\"" << result.reason
+          << "\",\"rms_acceleration\":" << acceleration_rms << ",\"rms_jerk\":" << jerk_rms
+          << ",\"rms_yaw_rate\":" << yaw_rate_rms << ",\"rms_yaw_accel\":" << yaw_acceleration_rms
+          << "}";
+  result.debug_summary = summary.str();
   return result;
 }
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.hpp
@@ -18,6 +18,7 @@
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
@@ -35,6 +36,12 @@ struct ExtendedComfortResult
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
+  std::string debug_summary;
+  std::vector<double> sample_times;
+  std::vector<double> delta_acceleration;
+  std::vector<double> delta_jerk;
+  std::vector<double> delta_yaw_rate;
+  std::vector<double> delta_yaw_accel;
 };
 
 /**

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <sstream>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -37,6 +38,7 @@ struct ComfortState
   geometry_msgs::msg::Pose pose;
   double longitudinal_acceleration_mps2{0.0};
   double lateral_acceleration_mps2{0.0};
+  double segment_id{2.0};
 };
 
 template <typename MessageT>
@@ -81,6 +83,7 @@ ComfortState make_state_from_odometry(
   ComfortState state;
   state.time_s = relative_time_s;
   state.pose = odometry.pose.pose;
+  state.segment_id = 0.0;
   if (acceleration) {
     // Note: This assumes the acceleration is in the vehicle body frame (base_link).
     state.longitudinal_acceleration_mps2 = acceleration->accel.accel.linear.x;
@@ -166,7 +169,13 @@ void calculate_history_comfort_metrics(
 
   std::vector<ComfortSignalInput> signal_inputs;
   signal_inputs.reserve(states.size());
+  metrics.history_comfort_sample_times.reserve(states.size());
+  metrics.history_comfort_segment_ids.reserve(states.size());
+  metrics.history_comfort_sample_poses.reserve(states.size());
   for (const auto & state : states) {
+    metrics.history_comfort_sample_times.push_back(state.time_s);
+    metrics.history_comfort_segment_ids.push_back(state.segment_id);
+    metrics.history_comfort_sample_poses.push_back(state.pose);
     signal_inputs.push_back(
       ComfortSignalInput{
         state.time_s, state.pose, state.longitudinal_acceleration_mps2,
@@ -203,6 +212,19 @@ void calculate_history_comfort_metrics(
                               : 0.0;
   metrics.history_comfort_available = true;
   metrics.history_comfort_reason = "available";
+
+  std::ostringstream summary;
+  summary << "{\"score\":" << metrics.history_comfort << ",\"sample_count\":" << states.size()
+          << ",\"past_horizon_s\":" << history_comfort_params.past_horizon_s
+          << ",\"future_horizon_s\":" << history_comfort_params.future_horizon_s
+          << ",\"longitudinal_acceleration_ok\":"
+          << (longitudinal_acceleration_ok ? "true" : "false")
+          << ",\"lateral_acceleration_ok\":" << (lateral_acceleration_ok ? "true" : "false")
+          << ",\"jerk_magnitude_ok\":" << (jerk_magnitude_ok ? "true" : "false")
+          << ",\"longitudinal_jerk_ok\":" << (longitudinal_jerk_ok ? "true" : "false")
+          << ",\"yaw_rate_ok\":" << (yaw_rate_ok ? "true" : "false")
+          << ",\"yaw_acceleration_ok\":" << (yaw_acceleration_ok ? "true" : "false") << "}";
+  metrics.history_comfort_debug_summary = summary.str();
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
@@ -22,32 +22,41 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-double calculate_lane_keeping_score(
+LaneKeepingResult calculate_lane_keeping_result(
   const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
   const LaneKeepingParameters & parameters,
-  const std::vector<std::pair<double, double>> & lane_change_windows_s)
+  const std::vector<std::pair<double, double>> & lane_change_windows_s, const bool collect_debug)
 {
+  LaneKeepingResult result;
   if (
     evaluation_points.empty() || parameters.max_lateral_deviation < 0.0 ||
     parameters.max_continuous_violation_time < 0.0) {
-    return 0.0;
+    return result;
   }
 
   std::optional<rclcpp::Duration> violation_start_time;
+  std::optional<std::size_t> violation_start_index;
+  double max_violation_duration = 0.0;
+  double peak_abs_lateral_deviation = 0.0;
+  bool failure_recorded = false;
   std::optional<double> queue_release_until_s;
 
-  const auto reset_violation_run = [&]() { violation_start_time.reset(); };
+  if (collect_debug) {
+    result.debug.samples.reserve(evaluation_points.size());
+  }
+
+  const auto reset_violation_run = [&]() {
+    violation_start_time.reset();
+    violation_start_index.reset();
+  };
 
   for (std::size_t index = 0; index < evaluation_points.size(); ++index) {
     const auto & evaluation_point = evaluation_points[index];
     const double time_s = evaluation_point.time_from_start.seconds();
-    if (!std::isfinite(evaluation_point.lateral_deviation)) {
-      reset_violation_run();
-      continue;
-    }
+    const bool finite = std::isfinite(evaluation_point.lateral_deviation);
 
     const bool over_threshold =
-      std::abs(evaluation_point.lateral_deviation) > parameters.max_lateral_deviation;
+      finite && std::abs(evaluation_point.lateral_deviation) > parameters.max_lateral_deviation;
     const bool lane_change_exempt = std::any_of(
       lane_change_windows_s.begin(), lane_change_windows_s.end(),
       [&](const auto & window) { return time_s >= window.first && time_s <= window.second; });
@@ -74,6 +83,22 @@ double calculate_lane_keeping_score(
     }
     const bool queue_release_exempt =
       !queue_exempt && queue_release_until_s.has_value() && time_s <= *queue_release_until_s;
+    if (collect_debug) {
+      result.debug.samples.push_back(
+        LaneKeepingDebugSample{
+          time_s, evaluation_point.ego_center, evaluation_point.lateral_deviation,
+          evaluation_point.is_in_intersection, over_threshold, false, lane_change_exempt,
+          queue_exempt, queue_release_exempt, evaluation_point.reference_centerline,
+          evaluation_point.reference_lanelet_id});
+    }
+
+    if (!finite) {
+      reset_violation_run();
+      continue;
+    }
+
+    peak_abs_lateral_deviation =
+      std::max(peak_abs_lateral_deviation, std::abs(evaluation_point.lateral_deviation));
 
     // Reset the violation run on any exemption: intersection samples, signalled lane-change
     // windows, queue, queue-release grace, or sub-threshold deviation.
@@ -85,16 +110,43 @@ double calculate_lane_keeping_score(
     }
     if (!violation_start_time.has_value()) {
       violation_start_time = evaluation_point.time_from_start;
+      violation_start_index = index;
     }
 
     const double violation_duration =
       (evaluation_point.time_from_start - *violation_start_time).seconds();
-    if (violation_duration >= parameters.max_continuous_violation_time) {
-      return 0.0;
+    max_violation_duration = std::max(max_violation_duration, violation_duration);
+    if (!failure_recorded && violation_duration >= parameters.max_continuous_violation_time) {
+      result.score = 0.0;
+      result.debug.first_failure_time_s = time_s;
+      result.debug.failure_run_start_time_s = violation_start_time->seconds();
+      result.debug.failure_run_end_time_s = time_s;
+      if (collect_debug && violation_start_index.has_value()) {
+        for (std::size_t run_index = *violation_start_index; run_index <= index; ++run_index) {
+          result.debug.samples.at(run_index).in_failure_run = true;
+        }
+        result.debug.label_anchor = result.debug.samples.at(*violation_start_index).ego_center;
+      }
+      failure_recorded = true;
     }
   }
 
-  return 1.0;
+  result.score = failure_recorded ? 0.0 : 1.0;
+  result.debug.max_continuous_violation_time_s = max_violation_duration;
+  result.debug.peak_abs_lateral_deviation_m = peak_abs_lateral_deviation;
+  if (collect_debug && !failure_recorded && !result.debug.samples.empty()) {
+    result.debug.label_anchor = result.debug.samples.front().ego_center;
+  }
+  return result;
+}
+
+double calculate_lane_keeping_score(
+  const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
+  const LaneKeepingParameters & parameters,
+  const std::vector<std::pair<double, double>> & lane_change_windows_s)
+{
+  return calculate_lane_keeping_result(evaluation_points, parameters, lane_change_windows_s, false)
+    .score;
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.hpp
@@ -17,7 +17,11 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <geometry_msgs/msg/point.hpp>
+
+#include <cstdint>
 #include <limits>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -43,6 +47,41 @@ struct LaneKeepingEvaluationPoint
   bool is_in_intersection{false};
   double speed_mps{std::numeric_limits<double>::quiet_NaN()};
   double cumulative_progress_m{std::numeric_limits<double>::quiet_NaN()};
+  geometry_msgs::msg::Point ego_center{};
+  std::vector<geometry_msgs::msg::Point> reference_centerline;
+  std::int64_t reference_lanelet_id{-1};
+};
+
+struct LaneKeepingDebugSample
+{
+  double time_s{0.0};
+  geometry_msgs::msg::Point ego_center{};
+  double lateral_deviation{0.0};
+  bool is_in_intersection{false};
+  bool over_threshold{false};
+  bool in_failure_run{false};
+  bool lane_change_exempt{false};
+  bool queue_exempt{false};
+  bool queue_release_exempt{false};
+  std::vector<geometry_msgs::msg::Point> reference_centerline;
+  std::int64_t reference_lanelet_id{-1};
+};
+
+struct LaneKeepingDebugInfo
+{
+  std::vector<LaneKeepingDebugSample> samples;
+  double first_failure_time_s{std::numeric_limits<double>::infinity()};
+  double failure_run_start_time_s{std::numeric_limits<double>::infinity()};
+  double failure_run_end_time_s{std::numeric_limits<double>::infinity()};
+  double max_continuous_violation_time_s{0.0};
+  double peak_abs_lateral_deviation_m{0.0};
+  geometry_msgs::msg::Point label_anchor{};
+};
+
+struct LaneKeepingResult
+{
+  double score{0.0};
+  LaneKeepingDebugInfo debug;
 };
 
 /**
@@ -51,6 +90,12 @@ struct LaneKeepingEvaluationPoint
  * Returns `0.0` when the continuous over-threshold duration reaches the configured limit,
  * otherwise returns `1.0`.
  */
+LaneKeepingResult calculate_lane_keeping_result(
+  const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
+  const LaneKeepingParameters & parameters = LaneKeepingParameters{},
+  const std::vector<std::pair<double, double>> & lane_change_windows_s = {},
+  bool collect_debug = false);
+
 double calculate_lane_keeping_score(
   const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
   const LaneKeepingParameters & parameters = LaneKeepingParameters{},

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
@@ -17,7 +17,9 @@
 #include "metrics/geometry/ego_footprint.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <boost/geometry.hpp>
 
@@ -26,8 +28,10 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -60,29 +64,61 @@ struct AtFaultCollision
   std::string reason{"available"};
 };
 
+struct CollisionClassification
+{
+  CollisionType type{CollisionType::ActiveLateral};
+  bool ego_stopped{false};
+  bool track_stopped{false};
+  bool behind{false};
+  bool front_hit{false};
+  std::vector<geometry_msgs::msg::Point> front_bumper;
+};
+
+std::string collision_type_to_string(const CollisionType type)
+{
+  switch (type) {
+    case CollisionType::StoppedEgo:
+      return "STOPPED_EGO";
+    case CollisionType::StoppedTrack:
+      return "STOPPED_TRACK";
+    case CollisionType::ActiveRear:
+      return "ACTIVE_REAR";
+    case CollisionType::ActiveFront:
+      return "ACTIVE_FRONT";
+    case CollisionType::ActiveLateral:
+      return "ACTIVE_LATERAL";
+  }
+  return "NONE";
+}
+
 double ego_speed(const autoware_planning_msgs::msg::TrajectoryPoint & point)
 {
   return std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps);
 }
 
-bool front_bumper_intersects(
-  const geometry_msgs::msg::Pose & ego_pose, const Polygon2d & object_polygon,
+std::vector<geometry_msgs::msg::Point> front_bumper_points(
+  const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
-  const double yaw = get_yaw(ego_pose.orientation);
-  const double c = std::cos(yaw);
-  const double s = std::sin(yaw);
-  const auto transform = [&](const double x_local, const double y_local) {
-    return Point2d{
-      ego_pose.position.x + c * x_local - s * y_local,
-      ego_pose.position.y + s * x_local + c * y_local};
-  };
+  return {
+    autoware_utils_geometry::calc_offset_pose(
+      ego_pose, vehicle_info.max_longitudinal_offset_m, vehicle_info.min_lateral_offset_m, 0.0, 0.0)
+      .position,
+    autoware_utils_geometry::calc_offset_pose(
+      ego_pose, vehicle_info.max_longitudinal_offset_m, vehicle_info.max_lateral_offset_m, 0.0, 0.0)
+      .position};
+}
 
+bool front_bumper_intersects(
+  const std::vector<geometry_msgs::msg::Point> & front_bumper_points,
+  const Polygon2d & object_polygon)
+{
+  if (front_bumper_points.size() < 2U) {
+    return false;
+  }
   bg::model::linestring<Point2d> front_bumper;
-  front_bumper.push_back(
-    transform(vehicle_info.max_longitudinal_offset_m, vehicle_info.min_lateral_offset_m));
-  front_bumper.push_back(
-    transform(vehicle_info.max_longitudinal_offset_m, vehicle_info.max_lateral_offset_m));
+  front_bumper.push_back(Point2d{front_bumper_points.at(0).x, front_bumper_points.at(0).y});
+  front_bumper.push_back(Point2d{front_bumper_points.at(1).x, front_bumper_points.at(1).y});
   return bg::intersects(front_bumper, object_polygon);
 }
 
@@ -92,24 +128,34 @@ bool is_track_stopped(const InterpolatedLoggedObject & object_state)
          object_state.speed_mps <= kStoppedVelocityThresholdMps;
 }
 
-CollisionType classify_collision(
+CollisionClassification classify_collision(
   const autoware_planning_msgs::msg::TrajectoryPoint & ego_point,
   const InterpolatedLoggedObject & object_state,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
-  if (ego_speed(ego_point) <= kStoppedVelocityThresholdMps) {
-    return CollisionType::StoppedEgo;
+  CollisionClassification collision;
+  collision.ego_stopped = ego_speed(ego_point) <= kStoppedVelocityThresholdMps;
+  collision.track_stopped = is_track_stopped(object_state);
+  collision.behind = is_agent_behind(ego_point.pose, object_state.pose);
+  collision.front_bumper = front_bumper_points(ego_point.pose, vehicle_info);
+  collision.front_hit = front_bumper_intersects(collision.front_bumper, object_state.polygon);
+  if (collision.ego_stopped) {
+    collision.type = CollisionType::StoppedEgo;
+    return collision;
   }
-  if (is_track_stopped(object_state)) {
-    return CollisionType::StoppedTrack;
+  if (collision.track_stopped) {
+    collision.type = CollisionType::StoppedTrack;
+    return collision;
   }
-  if (is_agent_behind(ego_point.pose, object_state.pose)) {
-    return CollisionType::ActiveRear;
+  if (collision.behind) {
+    collision.type = CollisionType::ActiveRear;
+    return collision;
   }
-  if (front_bumper_intersects(ego_point.pose, object_state.polygon, vehicle_info)) {
-    return CollisionType::ActiveFront;
+  if (collision.front_hit) {
+    collision.type = CollisionType::ActiveFront;
+    return collision;
   }
-  return CollisionType::ActiveLateral;
+  return collision;
 }
 
 AtFaultCollision make_at_fault_collision(
@@ -123,6 +169,105 @@ AtFaultCollision make_at_fault_collision(
   return AtFaultCollision{score, collision_scope + "_" + object_kind};
 }
 
+NoAtFaultCollisionDebugEvent make_debug_event(
+  const double query_time_s, const autoware_planning_msgs::msg::TrajectoryPoint & ego_point,
+  const Polygon2d & ego_polygon, const InterpolatedLoggedObject & object_state,
+  const CollisionClassification & collision)
+{
+  const double debug_surface_z = ego_point.pose.position.z;
+  NoAtFaultCollisionDebugEvent event;
+  event.time_s = query_time_s;
+  event.object_id = object_id_to_string(object_state.object_id, object_state.has_valid_object_id);
+  event.object_label =
+    autoware::object_recognition_utils::convertLabelToString(object_state.classification);
+  event.collision_type = collision_type_to_string(collision.type);
+  event.agent = is_agent_classification(object_state.classification);
+  event.ego_stopped = collision.ego_stopped;
+  event.track_stopped = collision.track_stopped;
+  event.behind = collision.behind;
+  event.front_hit = collision.front_hit;
+  event.ego_center = to_msg_point(ego_point.pose);
+  event.object_center = to_msg_point(object_state.pose);
+  event.ego_footprint = polygon_to_points(ego_polygon, debug_surface_z);
+  event.object_footprint = polygon_to_points(object_state.polygon, debug_surface_z);
+  event.front_bumper = collision.front_bumper;
+  return event;
+}
+
+void fill_horizon_debug_footprints(
+  NoAtFaultCollisionDebugInfo & debug_info,
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<LoggedObjectTrack> & object_tracks,
+  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations)
+{
+  if (debug_info.events.empty()) {
+    return;
+  }
+
+  std::unordered_set<std::string> engaged_objects;
+  for (const auto & event : debug_info.events) {
+    engaged_objects.insert(event.object_id);
+  }
+  const auto trajectory_start_time = rclcpp::Time(trajectory.header.stamp);
+  for (size_t index = 0; index < trajectory.points.size(); ++index) {
+    const auto & point = trajectory.points.at(index);
+    const auto query_time = trajectory_start_time + rclcpp::Duration(point.time_from_start);
+    const double query_time_s = rclcpp::Duration(point.time_from_start).seconds();
+    const auto & ego_polygon = footprint_evaluations.at(index).ego_polygon;
+    bool ego_collision = false;
+    bool ego_at_fault = false;
+    for (const auto & object_track : object_tracks) {
+      const auto object_id =
+        object_id_to_string(object_track.object_id, object_track.has_valid_object_id);
+      if (engaged_objects.count(object_id) == 0U) {
+        continue;
+      }
+      const auto object_state = interpolate_logged_object_state(object_track, query_time);
+      if (!object_state.has_value()) {
+        continue;
+      }
+      const bool intersects = bg::intersects(ego_polygon, object_state->polygon);
+      const bool object_at_fault = std::any_of(
+        debug_info.events.begin(), debug_info.events.end(),
+        [&](const auto & event) { return event.object_id == object_id && event.at_fault; });
+      ego_collision = ego_collision || intersects;
+      ego_at_fault = ego_at_fault || (intersects && object_at_fault);
+
+      NoAtFaultCollisionHorizonFootprint object_footprint;
+      object_footprint.time_s = query_time_s;
+      object_footprint.object_id = object_id;
+      object_footprint.object_label =
+        autoware::object_recognition_utils::convertLabelToString(object_state->classification);
+      object_footprint.collision = intersects;
+      object_footprint.at_fault = intersects && object_at_fault;
+      object_footprint.footprint = polygon_to_points(object_state->polygon, point.pose.position.z);
+      debug_info.object_horizon_footprints.push_back(std::move(object_footprint));
+
+      if (intersects) {
+        for (const auto & overlap_polygon : overlap_polygons_to_points(
+               ego_polygon, object_state->polygon, point.pose.position.z)) {
+          NoAtFaultCollisionOverlapArea overlap_area;
+          overlap_area.time_s = query_time_s;
+          overlap_area.object_id = object_id;
+          overlap_area.object_label =
+            autoware::object_recognition_utils::convertLabelToString(object_state->classification);
+          overlap_area.at_fault = object_at_fault;
+          overlap_area.polygon = overlap_polygon;
+          debug_info.overlap_areas.push_back(std::move(overlap_area));
+        }
+      }
+    }
+    NoAtFaultCollisionHorizonFootprint ego_footprint;
+    ego_footprint.time_s = query_time_s;
+    ego_footprint.object_id = "ego";
+    ego_footprint.object_label = "EGO";
+    ego_footprint.collision = ego_collision;
+    ego_footprint.at_fault = ego_at_fault;
+    ego_footprint.footprint = polygon_to_points(ego_polygon, point.pose.position.z);
+    debug_info.ego_horizon_footprints.push_back(std::move(ego_footprint));
+  }
+}
+
 }  // namespace
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
@@ -130,7 +275,8 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const std::vector<LoggedObjectTrack> & object_tracks,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler,
-  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations)
+  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations,
+  const bool collect_debug)
 {
   NoAtFaultCollisionResult result;
 
@@ -196,13 +342,23 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
         continue;
       }
 
-      const auto collision_type = classify_collision(point, *object_state, vehicle_info);
-      const bool front_or_stopped_track = collision_type == CollisionType::ActiveFront ||
-                                          collision_type == CollisionType::StoppedTrack;
-      const bool lateral_collision = collision_type == CollisionType::ActiveLateral;
+      const auto collision = classify_collision(point, *object_state, vehicle_info);
+      auto make_optional_debug_event = [&]() {
+        return make_debug_event(query_time_s, point, ego_polygon, *object_state, collision);
+      };
+      const bool front_or_stopped_track = collision.type == CollisionType::ActiveFront ||
+                                          collision.type == CollisionType::StoppedTrack;
+      const bool lateral_collision = collision.type == CollisionType::ActiveLateral;
 
       if (front_or_stopped_track) {
         const auto at_fault_collision = make_at_fault_collision(*object_state, false);
+        if (collect_debug) {
+          auto debug_event = make_optional_debug_event();
+          debug_event.at_fault = true;
+          debug_event.event_score = at_fault_collision.score;
+          debug_event.reason = at_fault_collision.reason;
+          result.debug_info.events.push_back(std::move(debug_event));
+        }
         record_at_fault_collision(*object_state, at_fault_collision, query_time_s);
         continue;
       }
@@ -210,6 +366,13 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
       if (lateral_collision) {
         const auto & ego_area_evaluation = footprint_evaluations.at(index).ego_area_evaluation;
         if (!ego_area_evaluation.has_value()) {
+          if (collect_debug) {
+            auto debug_event = make_optional_debug_event();
+            debug_event.reason = !route_handler
+                                   ? "unavailable_no_route_handler_for_lateral_assessment"
+                                   : "unavailable_route_handler_not_ready_for_lateral_assessment";
+            result.debug_info.events.push_back(std::move(debug_event));
+          }
           result.available = false;
           result.score = 0.0;
           result.reason = !route_handler
@@ -218,17 +381,39 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
           return result;
         }
 
+        std::optional<NoAtFaultCollisionDebugEvent> debug_event;
+        if (collect_debug) {
+          debug_event = make_optional_debug_event();
+          debug_event->multiple_lanes = ego_area_evaluation->flags.multiple_lanes;
+          debug_event->non_drivable_area = ego_area_evaluation->flags.non_drivable_area;
+        }
         if (
           ego_area_evaluation->flags.multiple_lanes ||
           ego_area_evaluation->flags.non_drivable_area) {
           const auto at_fault_collision = make_at_fault_collision(*object_state, true);
+          if (debug_event.has_value()) {
+            debug_event->at_fault = true;
+            debug_event->event_score = at_fault_collision.score;
+            debug_event->reason = at_fault_collision.reason;
+          }
           record_at_fault_collision(*object_state, at_fault_collision, query_time_s);
         }
+        if (debug_event.has_value()) {
+          result.debug_info.events.push_back(std::move(*debug_event));
+        }
         continue;
+      }
+
+      if (collect_debug) {
+        result.debug_info.events.push_back(make_optional_debug_event());
       }
     }
   }
 
+  if (collect_debug) {
+    fill_horizon_debug_footprints(
+      result.debug_info, trajectory, object_tracks, footprint_evaluations);
+  }
   return result;
 }
 
@@ -236,7 +421,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<RouteHandler> & route_handler, const bool collect_debug)
 {
   if (future_objects.empty()) {
     NoAtFaultCollisionResult result;
@@ -247,7 +432,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const auto footprint_evaluations =
     evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
   return calculate_no_at_fault_collision(
-    trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations);
+    trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations, collect_debug);
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
@@ -22,6 +22,8 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
+#include <geometry_msgs/msg/point.hpp>
+
 #include <limits>
 #include <memory>
 #include <string>
@@ -32,12 +34,63 @@ namespace autoware::planning_data_analyzer::metrics
 
 using autoware::route_handler::RouteHandler;
 
+struct NoAtFaultCollisionDebugEvent
+{
+  double time_s{0.0};
+  std::string object_id{"invalid"};
+  std::string object_label{"UNKNOWN"};
+  std::string collision_type{"NONE"};
+  std::string reason{"available"};
+  double event_score{1.0};
+  bool agent{false};
+  bool at_fault{false};
+  bool ego_stopped{false};
+  bool track_stopped{false};
+  bool behind{false};
+  bool front_hit{false};
+  bool multiple_lanes{false};
+  bool non_drivable_area{false};
+  geometry_msgs::msg::Point ego_center;
+  geometry_msgs::msg::Point object_center;
+  std::vector<geometry_msgs::msg::Point> ego_footprint;
+  std::vector<geometry_msgs::msg::Point> object_footprint;
+  std::vector<geometry_msgs::msg::Point> front_bumper;
+};
+
+struct NoAtFaultCollisionHorizonFootprint
+{
+  double time_s{0.0};
+  std::string object_id{"ego"};
+  std::string object_label{"EGO"};
+  bool collision{false};
+  bool at_fault{false};
+  std::vector<geometry_msgs::msg::Point> footprint;
+};
+
+struct NoAtFaultCollisionOverlapArea
+{
+  double time_s{0.0};
+  std::string object_id{"invalid"};
+  std::string object_label{"UNKNOWN"};
+  bool at_fault{false};
+  std::vector<geometry_msgs::msg::Point> polygon;
+};
+
+struct NoAtFaultCollisionDebugInfo
+{
+  std::vector<NoAtFaultCollisionDebugEvent> events;
+  std::vector<NoAtFaultCollisionHorizonFootprint> ego_horizon_footprints;
+  std::vector<NoAtFaultCollisionHorizonFootprint> object_horizon_footprints;
+  std::vector<NoAtFaultCollisionOverlapArea> overlap_areas;
+};
+
 struct NoAtFaultCollisionResult
 {
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
   double infraction_time_s{std::numeric_limits<double>::infinity()};
+  NoAtFaultCollisionDebugInfo debug_info;
 };
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
@@ -45,13 +98,14 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const std::vector<LoggedObjectTrack> & object_tracks,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler,
-  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations);
+  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations,
+  bool collect_debug = false);
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr);
+  const std::shared_ptr<RouteHandler> & route_handler = nullptr, bool collect_debug = false);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -40,6 +41,34 @@ namespace
 {
 
 using TurnDirection = autoware::experimental::lanelet2_utils::TurnDirection;
+
+std::vector<geometry_msgs::msg::Point> line_points(
+  const lanelet::ConstLineString3d & line, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(line.size());
+  for (const auto & point : line) {
+    points.push_back(
+      autoware_utils_geometry::to_msg(autoware_utils_geometry::Point3d{point.x(), point.y(), z}));
+  }
+  return points;
+}
+
+std::string turn_direction_to_string(const std::optional<TurnDirection> & turn_direction)
+{
+  if (!turn_direction.has_value()) {
+    return "unknown";
+  }
+  switch (*turn_direction) {
+    case TurnDirection::Straight:
+      return "straight";
+    case TurnDirection::Left:
+      return "left";
+    case TurnDirection::Right:
+      return "right";
+  }
+  return "unknown";
+}
 
 struct RelevantTrafficLightGroup
 {
@@ -202,7 +231,7 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status,
   const std::vector<TrajectoryFootprintEvaluation> * evaluations,
-  const lanelet::ConstLanelets * route_relevant_lanelets)
+  const lanelet::ConstLanelets * route_relevant_lanelets, const bool collect_debug)
 {
   TrafficLightComplianceResult result;
 
@@ -230,6 +259,24 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
     route_relevant_lanelets ? *route_relevant_lanelets : local_route_lanelets;
   const auto groups =
     build_relevant_traffic_light_groups(route_lanelets, route_handler, turn_indicators_status);
+  for (const auto & group : groups) {
+    if (collect_debug) {
+      result.debug_info.regulatory_element_ids.push_back(group.regulatory_element_id);
+      result.debug_info.intended_movement = turn_direction_to_string(group.intended_turn_direction);
+      for (const auto & lanelet : group.selected_lanelets) {
+        result.debug_info.selected_lane_ids.push_back(lanelet.id());
+      }
+      if (group.stop_line.has_value()) {
+        result.debug_info.stop_line_ids.push_back(group.stop_line->id());
+        result.debug_info.stop_lines.push_back(
+          TrafficLightComplianceDebugPolygon{
+            0.0, line_points(*group.stop_line, trajectory.points.front().pose.position.z),
+            group.stop_line->id()});
+      }
+    }
+  }
+  result.debug_info.selected_stop_line_count =
+    collect_debug ? result.debug_info.stop_lines.size() : 0U;
   result.available = true;
   result.reason = groups.empty() ? "available_no_relevant_traffic_lights" : "available";
   result.score = 1.0;
@@ -248,12 +295,19 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
   const auto local_footprint = vehicle_info.createFootprint(0.0);
   const bool can_reuse_evaluations =
     evaluations != nullptr && evaluations->size() == trajectory.points.size();
+  bool violation_found = false;
 
   for (std::size_t point_index = 0; point_index < trajectory.points.size(); ++point_index) {
     const auto & point = trajectory.points.at(point_index);
     const auto ego_polygon = can_reuse_evaluations
                                ? evaluations->at(point_index).ego_polygon
                                : create_pose_footprint(point.pose, local_footprint);
+    if (collect_debug) {
+      result.debug_info.ego_horizon_footprints.push_back(
+        TrafficLightComplianceDebugPolygon{
+          rclcpp::Duration(point.time_from_start).seconds(),
+          polygon_to_points(ego_polygon, point.pose.position.z), 0});
+    }
 
     for (const auto & group : groups) {
       if (!group.stop_line.has_value()) {
@@ -278,10 +332,21 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
         continue;
       }
 
-      result.reason = "red_light_stop_line_crossed";
-      result.score = 0.0;
-      return result;
+      if (!violation_found) {
+        violation_found = true;
+        result.reason = "red_light_stop_line_crossed";
+        result.score = 0.0;
+        if (collect_debug) {
+          result.debug_info.first_failure_time_s =
+            rclcpp::Duration(point.time_from_start).seconds();
+          result.debug_info.label_anchor = point.pose.position;
+        }
+      }
     }
+  }
+
+  if (violation_found) {
+    return result;
   }
 
   if (!missing_signal_ids_at_relevant_stop_line.empty()) {

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.hpp
@@ -23,6 +23,7 @@
 
 #include <lanelet2_core/primitives/Lanelet.h>
 
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -33,11 +34,32 @@ namespace autoware::planning_data_analyzer::metrics
 
 using autoware::route_handler::RouteHandler;
 
+struct TrafficLightComplianceDebugPolygon
+{
+  double time_s{0.0};
+  std::vector<geometry_msgs::msg::Point> polygon;
+  lanelet::Id source_id{0};
+};
+
+struct TrafficLightComplianceDebugInfo
+{
+  double first_failure_time_s{std::numeric_limits<double>::infinity()};
+  geometry_msgs::msg::Point label_anchor;
+  std::vector<TrafficLightComplianceDebugPolygon> ego_horizon_footprints;
+  std::vector<TrafficLightComplianceDebugPolygon> stop_lines;
+  std::vector<lanelet::Id> regulatory_element_ids;
+  std::vector<lanelet::Id> selected_lane_ids;
+  std::vector<lanelet::Id> stop_line_ids;
+  std::size_t selected_stop_line_count{0};
+  std::optional<std::string> intended_movement;
+};
+
 struct TrafficLightComplianceResult
 {
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
+  TrafficLightComplianceDebugInfo debug_info;
 };
 
 TrafficLightComplianceResult calculate_traffic_light_compliance(
@@ -47,7 +69,7 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status = nullptr,
   const std::vector<TrajectoryFootprintEvaluation> * evaluations = nullptr,
-  const lanelet::ConstLanelets * route_relevant_lanelets = nullptr);
+  const lanelet::ConstLanelets * route_relevant_lanelets = nullptr, bool collect_debug = false);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.cpp
@@ -19,6 +19,8 @@
 #include "metrics/geometry/metric_utils.hpp"
 #include "metrics/geometry/object_tracks.hpp"
 
+#include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <tf2/LinearMath/Vector3.hpp>
 
 #include <boost/geometry.hpp>
@@ -30,6 +32,7 @@
 #include <memory>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -39,6 +42,9 @@ using autoware::route_handler::RouteHandler;
 
 namespace
 {
+
+using autoware_utils_geometry::Polygon2d;
+namespace bg = boost::geometry;
 
 constexpr double kStoppedSpeedThreshold = 5.0e-3;
 constexpr std::array<double, 4> kFutureProjectionOffsetsSec{{0.0, 0.3, 0.6, 0.9}};
@@ -93,6 +99,120 @@ bool is_agent_behind_nuplan(
   return relative_agent_angle(ego_pose, object_pose) > kBehindAngleThresholdRad;
 }
 
+TTCWithinBoundDebugEvent make_debug_event(
+  const double time_s, const double future_offset_s, const double query_time_s,
+  const bool bad_or_intersection, const bool multiple_lanes, const bool non_drivable_area,
+  const bool intersection, const bool ahead, const bool behind,
+  const geometry_msgs::msg::Pose & projected_pose, const Polygon2d & ego_polygon,
+  const InterpolatedLoggedObject & object_state)
+{
+  TTCWithinBoundDebugEvent event;
+  event.time_s = time_s;
+  event.future_offset_s = future_offset_s;
+  event.query_time_s = query_time_s;
+  event.object_id = object_id_to_string(object_state.object_id, object_state.has_valid_object_id);
+  event.object_label =
+    autoware::object_recognition_utils::convertLabelToString(object_state.classification);
+  event.ahead = ahead;
+  event.behind = behind;
+  event.multiple_lanes = multiple_lanes;
+  event.non_drivable_area = non_drivable_area;
+  event.intersection = intersection;
+  event.bad_or_intersection = bad_or_intersection;
+  event.ego_center = to_msg_point(projected_pose);
+  event.object_center = to_msg_point(object_state.pose);
+  event.ego_footprint = polygon_to_points(ego_polygon, projected_pose.position.z);
+  event.object_footprint = polygon_to_points(object_state.polygon, projected_pose.position.z);
+  return event;
+}
+
+void populate_ttc_debug_horizon(
+  TTCWithinBoundDebugInfo & debug_info, const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::size_t failure_index, const autoware_planning_msgs::msg::TrajectoryPoint & point,
+  const tf2::Vector3 & velocity_world,
+  const autoware_utils_geometry::LinearRing2d & local_footprint,
+  const LoggedObjectTrack & object_track, const rclcpp::Time & trajectory_start_time,
+  const double failure_time_s, const double failure_future_offset_s, const std::string & object_id,
+  const std::string & object_label)
+{
+  for (std::size_t index = 0; index <= failure_index && index < trajectory.points.size(); ++index) {
+    const auto & prefix_point = trajectory.points.at(index);
+    const double prefix_time_s = rclcpp::Duration(prefix_point.time_from_start).seconds();
+    const auto prefix_query_time =
+      trajectory_start_time + rclcpp::Duration(prefix_point.time_from_start);
+    const auto prefix_ego_polygon = create_pose_footprint(prefix_point.pose, local_footprint);
+    TTCWithinBoundHorizonFootprint prefix_ego_footprint;
+    prefix_ego_footprint.time_s = prefix_time_s;
+    prefix_ego_footprint.object_id = "ego";
+    prefix_ego_footprint.object_label = "EGO";
+    prefix_ego_footprint.prefix = true;
+    prefix_ego_footprint.footprint =
+      polygon_to_points(prefix_ego_polygon, prefix_point.pose.position.z);
+    debug_info.ego_horizon_footprints.push_back(std::move(prefix_ego_footprint));
+
+    const auto prefix_object_state =
+      interpolate_logged_object_state(object_track, prefix_query_time);
+    if (prefix_object_state.has_value()) {
+      TTCWithinBoundHorizonFootprint prefix_object_footprint;
+      prefix_object_footprint.time_s = prefix_time_s;
+      prefix_object_footprint.object_id = object_id;
+      prefix_object_footprint.object_label = object_label;
+      prefix_object_footprint.prefix = true;
+      prefix_object_footprint.footprint =
+        polygon_to_points(prefix_object_state->polygon, prefix_point.pose.position.z);
+      debug_info.object_horizon_footprints.push_back(std::move(prefix_object_footprint));
+    }
+  }
+
+  for (const double future_offset_s : kFutureProjectionOffsetsSec) {
+    const double query_time_s = failure_time_s + future_offset_s;
+    const auto query_time = trajectory_start_time + rclcpp::Duration::from_seconds(query_time_s);
+    const auto projected_pose = project_pose(point.pose, velocity_world, future_offset_s);
+    const auto ego_polygon = create_pose_footprint(projected_pose, local_footprint);
+    TTCWithinBoundHorizonFootprint ego_footprint;
+    ego_footprint.time_s = query_time_s;
+    ego_footprint.future_offset_s = future_offset_s;
+    ego_footprint.object_id = "ego";
+    ego_footprint.object_label = "EGO";
+    ego_footprint.failing = std::abs(future_offset_s - failure_future_offset_s) < 1.0e-6;
+    ego_footprint.footprint = polygon_to_points(ego_polygon, projected_pose.position.z);
+
+    const auto object_state = interpolate_logged_object_state(object_track, query_time);
+    if (!object_state.has_value()) {
+      debug_info.ego_horizon_footprints.push_back(std::move(ego_footprint));
+      continue;
+    }
+    const bool overlap = bg::intersects(ego_polygon, object_state->polygon);
+    ego_footprint.overlap = overlap;
+    debug_info.ego_horizon_footprints.push_back(ego_footprint);
+
+    TTCWithinBoundHorizonFootprint object_footprint;
+    object_footprint.time_s = query_time_s;
+    object_footprint.future_offset_s = future_offset_s;
+    object_footprint.object_id = object_id;
+    object_footprint.object_label = object_label;
+    object_footprint.overlap = overlap;
+    object_footprint.failing = ego_footprint.failing;
+    object_footprint.footprint =
+      polygon_to_points(object_state->polygon, projected_pose.position.z);
+    debug_info.object_horizon_footprints.push_back(std::move(object_footprint));
+
+    if (overlap) {
+      for (const auto & overlap_polygon : overlap_polygons_to_points(
+             ego_polygon, object_state->polygon, projected_pose.position.z)) {
+        TTCWithinBoundOverlapArea overlap_area;
+        overlap_area.time_s = failure_time_s;
+        overlap_area.future_offset_s = future_offset_s;
+        overlap_area.object_id = object_id;
+        overlap_area.object_label = object_label;
+        overlap_area.failing = ego_footprint.failing;
+        overlap_area.polygon = overlap_polygon;
+        debug_info.overlap_areas.push_back(std::move(overlap_area));
+      }
+    }
+  }
+}
+
 }  // namespace
 
 TTCWithinBoundResult calculate_ttc_within_bound(
@@ -101,7 +221,7 @@ TTCWithinBoundResult calculate_ttc_within_bound(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler,
   const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations,
-  const std::vector<LoggedObjectTrack> * object_tracks)
+  const std::vector<LoggedObjectTrack> * object_tracks, const bool collect_debug)
 {
   TTCWithinBoundResult result;
 
@@ -206,6 +326,17 @@ TTCWithinBoundResult calculate_ttc_within_bound(
         const bool ahead = is_agent_ahead_nuplan(projected_pose, object_state->pose);
         const bool behind = is_agent_behind_nuplan(projected_pose, object_state->pose);
         if (ahead || (bad_or_intersection && !behind)) {
+          if (collect_debug) {
+            auto debug_event = make_debug_event(
+              time_s, future_offset_s, query_time_s, bad_or_intersection, multiple_lanes,
+              non_drivable_area, ego_in_intersection, ahead, behind, projected_pose, ego_polygon,
+              *object_state);
+            result.debug_info.events.push_back(debug_event);
+            populate_ttc_debug_horizon(
+              result.debug_info, trajectory, index, point, velocity_world, local_footprint,
+              object_track, trajectory_start_time, time_s, future_offset_s, debug_event.object_id,
+              debug_event.object_label);
+          }
           result.score = 0.0;
           result.reason = "collision_within_bound";
           result.infraction_time_s = query_time_s;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.hpp
@@ -22,6 +22,8 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
+#include <geometry_msgs/msg/point.hpp>
+
 #include <limits>
 #include <memory>
 #include <string>
@@ -32,12 +34,63 @@ namespace autoware::planning_data_analyzer::metrics
 
 using autoware::route_handler::RouteHandler;
 
+struct TTCWithinBoundDebugEvent
+{
+  double time_s{0.0};
+  double future_offset_s{0.0};
+  double query_time_s{0.0};
+  std::string object_id{"invalid"};
+  std::string object_label{"UNKNOWN"};
+  bool ahead{false};
+  bool behind{false};
+  bool multiple_lanes{false};
+  bool non_drivable_area{false};
+  bool intersection{false};
+  bool bad_or_intersection{false};
+  bool ego_stopped{false};
+  geometry_msgs::msg::Point ego_center;
+  geometry_msgs::msg::Point object_center;
+  std::vector<geometry_msgs::msg::Point> ego_footprint;
+  std::vector<geometry_msgs::msg::Point> object_footprint;
+};
+
+struct TTCWithinBoundOverlapArea
+{
+  double time_s{0.0};
+  double future_offset_s{0.0};
+  std::string object_id{"invalid"};
+  std::string object_label{"UNKNOWN"};
+  bool failing{false};
+  std::vector<geometry_msgs::msg::Point> polygon;
+};
+
+struct TTCWithinBoundHorizonFootprint
+{
+  double time_s{0.0};
+  double future_offset_s{0.0};
+  std::string object_id{"ego"};
+  std::string object_label{"EGO"};
+  bool prefix{false};
+  bool overlap{false};
+  bool failing{false};
+  std::vector<geometry_msgs::msg::Point> footprint;
+};
+
+struct TTCWithinBoundDebugInfo
+{
+  std::vector<TTCWithinBoundDebugEvent> events;
+  std::vector<TTCWithinBoundHorizonFootprint> ego_horizon_footprints;
+  std::vector<TTCWithinBoundHorizonFootprint> object_horizon_footprints;
+  std::vector<TTCWithinBoundOverlapArea> overlap_areas;
+};
+
 struct TTCWithinBoundResult
 {
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
   double infraction_time_s{std::numeric_limits<double>::infinity()};
+  TTCWithinBoundDebugInfo debug_info;
 };
 
 TTCWithinBoundResult calculate_ttc_within_bound(
@@ -46,7 +99,7 @@ TTCWithinBoundResult calculate_ttc_within_bound(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler = nullptr,
   const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr,
-  const std::vector<LoggedObjectTrack> * object_tracks = nullptr);
+  const std::vector<LoggedObjectTrack> * object_tracks = nullptr, bool collect_debug = false);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.cpp
@@ -14,10 +14,16 @@
 
 #include "metric_utils.hpp"
 
+#include <autoware_utils_uuid/uuid_helper.hpp>
+
+#include <boost/geometry.hpp>
+
 #include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>
+#include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
@@ -68,6 +74,57 @@ const autoware_perception_msgs::msg::PredictedPath * highest_confidence_path(
     object.kinematics.predicted_paths.begin(), object.kinematics.predicted_paths.end(),
     [](const auto & lhs, const auto & rhs) { return lhs.confidence < rhs.confidence; });
   return it == object.kinematics.predicted_paths.end() ? nullptr : &(*it);
+}
+
+std::string object_id_to_string(
+  const unique_identifier_msgs::msg::UUID & object_id, const bool valid)
+{
+  if (!valid) {
+    return "invalid";
+  }
+  return autoware_utils_uuid::to_hex_string(object_id);
+}
+
+geometry_msgs::msg::Point to_msg_point(
+  const autoware_utils_geometry::Point2d & point, const double z)
+{
+  return autoware_utils_geometry::to_msg(point.to_3d(z));
+}
+
+geometry_msgs::msg::Point to_msg_point(const geometry_msgs::msg::Pose & pose)
+{
+  geometry_msgs::msg::Point msg;
+  msg.x = pose.position.x;
+  msg.y = pose.position.y;
+  msg.z = pose.position.z;
+  return msg;
+}
+
+std::vector<geometry_msgs::msg::Point> polygon_to_points(
+  const autoware_utils_geometry::Polygon2d & polygon, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(polygon.outer().size());
+  for (const auto & point : polygon.outer()) {
+    points.push_back(to_msg_point(point, z));
+  }
+  return points;
+}
+
+std::vector<std::vector<geometry_msgs::msg::Point>> overlap_polygons_to_points(
+  const autoware_utils_geometry::Polygon2d & ego_polygon,
+  const autoware_utils_geometry::Polygon2d & object_polygon, const double z)
+{
+  std::vector<autoware_utils_geometry::Polygon2d> intersections;
+  boost::geometry::intersection(ego_polygon, object_polygon, intersections);
+  std::vector<std::vector<geometry_msgs::msg::Point>> polygons;
+  polygons.reserve(intersections.size());
+  for (const auto & intersection : intersections) {
+    if (intersection.outer().size() >= 4U && boost::geometry::area(intersection) > 1.0e-6) {
+      polygons.push_back(polygon_to_points(intersection, z));
+    }
+  }
+  return polygons;
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.hpp
@@ -16,10 +16,16 @@
 #define METRICS__GEOMETRY__METRIC_UTILS_HPP_
 
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
+#include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
@@ -36,6 +42,20 @@ bool is_agent_behind(
 
 const autoware_perception_msgs::msg::PredictedPath * highest_confidence_path(
   const autoware_perception_msgs::msg::PredictedObject & object);
+
+std::string object_id_to_string(const unique_identifier_msgs::msg::UUID & object_id, bool valid);
+
+geometry_msgs::msg::Point to_msg_point(
+  const autoware_utils_geometry::Point2d & point, double z = 0.0);
+
+geometry_msgs::msg::Point to_msg_point(const geometry_msgs::msg::Pose & pose);
+
+std::vector<geometry_msgs::msg::Point> polygon_to_points(
+  const autoware_utils_geometry::Polygon2d & polygon, double z);
+
+std::vector<std::vector<geometry_msgs::msg::Point>> overlap_polygons_to_points(
+  const autoware_utils_geometry::Polygon2d & ego_polygon,
+  const autoware_utils_geometry::Polygon2d & object_polygon, double z);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/trajectory_utils.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/trajectory_utils.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "trajectory_utils.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+#include <rclcpp/duration.hpp>
+
+#include <algorithm>
+
+namespace autoware::planning_data_analyzer::metrics
+{
+
+double point_time_s(const autoware_planning_msgs::msg::TrajectoryPoint & point)
+{
+  return rclcpp::Duration(point.time_from_start).seconds();
+}
+
+namespace
+{
+
+double lerp(const double lhs, const double rhs, const double ratio)
+{
+  return lhs + (rhs - lhs) * ratio;
+}
+
+}  // namespace
+
+autoware_planning_msgs::msg::TrajectoryPoint interpolate_trajectory_point(
+  const autoware_planning_msgs::msg::TrajectoryPoint & previous,
+  const autoware_planning_msgs::msg::TrajectoryPoint & next, const double horizon_s)
+{
+  const double previous_t = point_time_s(previous);
+  const double next_t = point_time_s(next);
+  const double ratio = next_t > previous_t
+                         ? std::clamp((horizon_s - previous_t) / (next_t - previous_t), 0.0, 1.0)
+                         : 0.0;
+
+  auto interpolated = previous;
+  interpolated.pose =
+    autoware_utils_geometry::calc_interpolated_pose(previous.pose, next.pose, ratio);
+  interpolated.longitudinal_velocity_mps =
+    lerp(previous.longitudinal_velocity_mps, next.longitudinal_velocity_mps, ratio);
+  interpolated.lateral_velocity_mps =
+    lerp(previous.lateral_velocity_mps, next.lateral_velocity_mps, ratio);
+  interpolated.acceleration_mps2 = lerp(previous.acceleration_mps2, next.acceleration_mps2, ratio);
+  interpolated.heading_rate_rps = lerp(previous.heading_rate_rps, next.heading_rate_rps, ratio);
+  interpolated.front_wheel_angle_rad =
+    lerp(previous.front_wheel_angle_rad, next.front_wheel_angle_rad, ratio);
+  interpolated.rear_wheel_angle_rad =
+    lerp(previous.rear_wheel_angle_rad, next.rear_wheel_angle_rad, ratio);
+  interpolated.time_from_start = rclcpp::Duration::from_seconds(horizon_s);
+  return interpolated;
+}
+
+autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const double horizon_s)
+{
+  constexpr double kTimeEpsilon = 1.0e-6;
+  if (horizon_s <= 0.0 || trajectory.points.empty()) {
+    return trajectory;
+  }
+
+  autoware_planning_msgs::msg::Trajectory truncated;
+  truncated.header = trajectory.header;
+  truncated.points.reserve(trajectory.points.size());
+
+  for (const auto & point : trajectory.points) {
+    const double t = point_time_s(point);
+    if (t <= horizon_s + kTimeEpsilon) {
+      truncated.points.push_back(point);
+      continue;
+    }
+
+    if (!truncated.points.empty()) {
+      const double previous_t = point_time_s(truncated.points.back());
+      if (previous_t < horizon_s - kTimeEpsilon) {
+        truncated.points.push_back(
+          interpolate_trajectory_point(truncated.points.back(), point, horizon_s));
+      }
+    }
+    if (truncated.points.empty()) {
+      truncated.points.push_back(point);
+    }
+    return truncated;
+  }
+
+  return truncated;
+}
+
+}  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/trajectory_utils.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/trajectory_utils.hpp
@@ -1,0 +1,35 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef METRICS__GEOMETRY__TRAJECTORY_UTILS_HPP_
+#define METRICS__GEOMETRY__TRAJECTORY_UTILS_HPP_
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+namespace autoware::planning_data_analyzer::metrics
+{
+
+double point_time_s(const autoware_planning_msgs::msg::TrajectoryPoint & point);
+
+autoware_planning_msgs::msg::TrajectoryPoint interpolate_trajectory_point(
+  const autoware_planning_msgs::msg::TrajectoryPoint & previous,
+  const autoware_planning_msgs::msg::TrajectoryPoint & next, double horizon_s);
+
+autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
+  const autoware_planning_msgs::msg::Trajectory & trajectory, double horizon_s);
+
+}  // namespace autoware::planning_data_analyzer::metrics
+
+#endif  // METRICS__GEOMETRY__TRAJECTORY_UTILS_HPP_

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -22,6 +22,7 @@
 #include "metrics/epdms/subscores/traffic_light_compliance.hpp"
 #include "metrics/epdms/subscores/ttc_within_bound.hpp"
 #include "metrics/geometry/ego_footprint.hpp"
+#include "metrics/geometry/lanelet_geometry.hpp"
 #include "metrics/geometry/lanelet_queries.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 
@@ -48,6 +49,44 @@ using autoware::route_handler::RouteHandler;
 
 namespace
 {
+
+geometry_msgs::msg::Point to_msg_point(
+  const geometry_msgs::msg::Point & point, const double z_offset = 0.0)
+{
+  geometry_msgs::msg::Point msg = point;
+  msg.z += z_offset;
+  return msg;
+}
+
+template <typename PointRange>
+std::vector<geometry_msgs::msg::Point> lanelet_points_to_msg(
+  const PointRange & lanelet_points, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  for (const auto & point : lanelet_points) {
+    points.push_back(
+      autoware_utils_geometry::to_msg(autoware_utils_geometry::Point3d{point.x(), point.y(), z}));
+  }
+  return points;
+}
+
+std::vector<geometry_msgs::msg::Point> lanelet_polygon_points(
+  const lanelet::ConstLanelet & lanelet, const double z)
+{
+  return lanelet_points_to_msg(lanelet.polygon3d(), z);
+}
+
+std::vector<geometry_msgs::msg::Point> polygon_points(
+  const lanelet::ConstPolygon3d & polygon, const double z)
+{
+  return lanelet_points_to_msg(polygon, z);
+}
+
+std::vector<geometry_msgs::msg::Point> centerline_points(
+  const lanelet::ConstLanelet & lanelet, const double z)
+{
+  return lanelet_points_to_msg(lanelet.centerline3d(), z);
+}
 
 template <typename MessageT, typename ActivePredicate>
 std::vector<std::pair<double, double>> collect_signal_active_windows(
@@ -272,7 +311,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   const LaneKeepingParameters & lane_keeping_params,
   const DrivingDirectionComplianceParameters & driving_direction_params,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::vector<TimedTrackedObjects> & future_objects)
+  const std::vector<TimedTrackedObjects> & future_objects,
+  const TrajectoryMetricDebugEnabledMetrics & debug_enabled_metrics)
 {
   TrajectoryPointMetrics metrics;
 
@@ -308,22 +348,26 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
                                : build_logged_object_tracks(logged_future_objects);
   const auto ttc_within_bound = calculate_ttc_within_bound(
     trajectory, logged_future_objects, vehicle_info, route_handler, &footprint_evaluations,
-    object_tracks.empty() ? nullptr : &object_tracks);
+    object_tracks.empty() ? nullptr : &object_tracks,
+    debug_enabled_metrics.time_to_collision_within_bound);
   metrics.time_to_collision_within_bound = ttc_within_bound.score;
   metrics.time_to_collision_within_bound_available = ttc_within_bound.available;
   metrics.time_to_collision_within_bound_reason = ttc_within_bound.reason;
   metrics.time_to_collision_infraction_time_s = ttc_within_bound.infraction_time_s;
+  metrics.time_to_collision_within_bound_debug = ttc_within_bound.debug_info;
   NoAtFaultCollisionResult no_at_fault_collision;
   if (logged_future_objects.empty()) {
     no_at_fault_collision.reason = "unavailable_no_future_objects";
   } else {
     no_at_fault_collision = calculate_no_at_fault_collision(
-      trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations);
+      trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations,
+      debug_enabled_metrics.no_at_fault_collision);
   }
   metrics.no_at_fault_collision = no_at_fault_collision.score;
   metrics.no_at_fault_collision_available = no_at_fault_collision.available;
   metrics.no_at_fault_collision_reason = no_at_fault_collision.reason;
   metrics.time_to_at_fault_collision_s = no_at_fault_collision.infraction_time_s;
+  metrics.no_at_fault_collision_debug = no_at_fault_collision.debug_info;
   if (!route_handler) {
     metrics.driving_direction_compliance_reason = "unavailable_no_route_handler";
   } else if (!route_handler->isHandlerReady()) {
@@ -352,6 +396,48 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.driving_direction_compliance_available = ddc_result.available;
     metrics.driving_direction_compliance_reason = ddc_result.reason;
     metrics.max_oncoming_progress_m = ddc_result.max_oncoming_progress_m;
+    metrics.driving_direction_compliance_debug.worst_window_start_time_s =
+      ddc_result.worst_window_start_time_s;
+    metrics.driving_direction_compliance_debug.worst_window_end_time_s =
+      ddc_result.worst_window_end_time_s;
+    metrics.driving_direction_compliance_debug.worst_window_sample_count =
+      ddc_result.worst_window_sample_count;
+    metrics.driving_direction_compliance_debug.window_progress_m =
+      ddc_result.max_oncoming_progress_m;
+    if (debug_enabled_metrics.driving_direction_compliance) {
+      for (size_t i = 0; i < driving_direction_evaluation_points.size(); ++i) {
+        const auto & evaluation_point = driving_direction_evaluation_points.at(i);
+        const auto & trajectory_point = trajectory.points.at(i);
+        const auto local_context =
+          compute_driving_direction_local_context(trajectory_point.pose, route_handler)
+            .value_or(DrivingDirectionLocalContext{});
+        const double counted_progress_m =
+          evaluation_point.in_oncoming_traffic && !evaluation_point.is_intersection
+            ? std::max(0.0, evaluation_point.progress_m)
+            : 0.0;
+        metrics.driving_direction_compliance_debug.samples.push_back(
+          DrivingDirectionDebugSample{
+            evaluation_point.time_from_start_s, evaluation_point.progress_m, counted_progress_m,
+            evaluation_point.in_oncoming_traffic, local_context.in_lane_margin_only,
+            evaluation_point.is_intersection, to_msg_point(trajectory_point.pose.position, 0.35)});
+        if (i == 0U) {
+          metrics.driving_direction_compliance_debug.label_anchor =
+            to_msg_point(trajectory_point.pose.position, 0.35);
+        }
+        for (const auto & lanelet : local_context.route_lanelets) {
+          metrics.driving_direction_compliance_debug.route_lane_polygons.push_back(
+            DrivingDirectionDebugPolygon{
+              evaluation_point.time_from_start_s,
+              lanelet_polygon_points(lanelet, trajectory_point.pose.position.z)});
+        }
+        for (const auto & polygon : local_context.intersection_areas) {
+          metrics.driving_direction_compliance_debug.intersection_lane_polygons.push_back(
+            DrivingDirectionDebugPolygon{
+              evaluation_point.time_from_start_s,
+              polygon_points(polygon, trajectory_point.pose.position.z)});
+        }
+      }
+    }
   }
 
   if (!route_handler) {
@@ -362,17 +448,21 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.traffic_light_compliance_reason = "unavailable_route_handler_not_ready";
   } else {
     const auto drivable_area_compliance = calculate_drivable_area_compliance(
-      trajectory, route_handler, vehicle_info, &footprint_evaluations);
+      trajectory, route_handler, vehicle_info, &footprint_evaluations,
+      debug_enabled_metrics.drivable_area_compliance);
     metrics.drivable_area_compliance = drivable_area_compliance.score;
     metrics.drivable_area_compliance_available = drivable_area_compliance.available;
     metrics.drivable_area_compliance_reason = drivable_area_compliance.reason;
+    metrics.drivable_area_compliance_debug = drivable_area_compliance.debug_info;
 
     const auto traffic_light_compliance = calculate_traffic_light_compliance(
       trajectory, sync_data->traffic_signals, route_handler, vehicle_info,
-      sync_data->turn_indicators_status, &footprint_evaluations, &route_relevant_lanelets);
+      sync_data->turn_indicators_status, &footprint_evaluations, &route_relevant_lanelets,
+      debug_enabled_metrics.traffic_light_compliance);
     metrics.traffic_light_compliance = traffic_light_compliance.score;
     metrics.traffic_light_compliance_available = traffic_light_compliance.available;
     metrics.traffic_light_compliance_reason = traffic_light_compliance.reason;
+    metrics.traffic_light_compliance_debug = traffic_light_compliance.debug_info;
   }
 
   const auto ego_progress = calculate_ego_progress(
@@ -440,9 +530,15 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
         metrics.lateral_deviations[i] = std::numeric_limits<double>::quiet_NaN();
         lane_keeping_evaluation_points.push_back(
           LaneKeepingEvaluationPoint{
-            point.time_from_start, metrics.lateral_deviations[i], false,
+            point.time_from_start,
+            metrics.lateral_deviations[i],
+            false,
             std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps),
-            metrics.travel_distances[i]});
+            metrics.travel_distances[i],
+            debug_enabled_metrics.lane_keeping ? to_msg_point(point.pose.position, 0.35)
+                                               : geometry_msgs::msg::Point{},
+            {},
+            -1});
       } else {
         metrics.lateral_deviations[i] =
           autoware::experimental::lanelet2_utils::get_lateral_distance_to_centerline(
@@ -454,7 +550,13 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
             point.time_from_start, metrics.lateral_deviations[i],
             local_context.has_value() && local_context->in_intersection,
             std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps),
-            metrics.travel_distances[i]});
+            metrics.travel_distances[i],
+            debug_enabled_metrics.lane_keeping ? to_msg_point(point.pose.position, 0.35)
+                                               : geometry_msgs::msg::Point{},
+            debug_enabled_metrics.lane_keeping
+              ? centerline_points(reference_lanelet.value(), point.pose.position.z)
+              : std::vector<geometry_msgs::msg::Point>{},
+            reference_lanelet->id()});
       }
     }
 
@@ -483,8 +585,11 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
       return std::isfinite(evaluation_point.lateral_deviation);
     });
   if (has_finite_lane_keeping_sample) {
-    metrics.lane_keeping = calculate_lane_keeping_score(
-      lane_keeping_evaluation_points, lane_keeping_params, lane_change_windows_s);
+    const auto lane_keeping_result = calculate_lane_keeping_result(
+      lane_keeping_evaluation_points, lane_keeping_params, lane_change_windows_s,
+      debug_enabled_metrics.lane_keeping);
+    metrics.lane_keeping = lane_keeping_result.score;
+    metrics.lane_keeping_debug = lane_keeping_result.debug;
     metrics.lane_keeping_available = true;
     metrics.lane_keeping_reason = "available";
   } else if (metrics.lane_keeping_reason == "unavailable") {

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
@@ -16,10 +16,13 @@
 #define METRICS__TRAJECTORY_METRICS_HPP_
 
 #include "data_types.hpp"
+#include "metrics/epdms/subscores/drivable_area_compliance.hpp"
 #include "metrics/epdms/subscores/driving_direction_compliance.hpp"
 #include "metrics/epdms/subscores/ego_progress.hpp"
 #include "metrics/epdms/subscores/lane_keeping.hpp"
+#include "metrics/epdms/subscores/no_at_fault_collision.hpp"
 #include "metrics/epdms/subscores/traffic_light_compliance.hpp"
+#include "metrics/epdms/subscores/ttc_within_bound.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
@@ -49,6 +52,16 @@ struct HistoryComfortParameters
   double max_yaw_acceleration{1.93};
 };
 
+struct TrajectoryMetricDebugEnabledMetrics
+{
+  bool time_to_collision_within_bound{false};
+  bool no_at_fault_collision{false};
+  bool drivable_area_compliance{false};
+  bool lane_keeping{false};
+  bool driving_direction_compliance{false};
+  bool traffic_light_compliance{false};
+};
+
 // Structure for trajectory point-wise metrics
 struct TrajectoryPointMetrics
 {
@@ -59,19 +72,25 @@ struct TrajectoryPointMetrics
   std::vector<double> longitudinal_jerks;
   std::vector<double> yaw_rates;
   std::vector<double> yaw_accelerations;
+  std::vector<double> history_comfort_sample_times;
+  std::vector<double> history_comfort_segment_ids;
+  std::vector<geometry_msgs::msg::Pose> history_comfort_sample_poses;
   std::vector<double> ttc_values;
   std::vector<double> lateral_deviations;
   std::vector<double> travel_distances;
   double history_comfort{0.0};
   bool history_comfort_available{false};
   std::string history_comfort_reason{"unavailable"};
+  std::string history_comfort_debug_summary;
   double time_to_collision_within_bound{0.0};
   bool time_to_collision_within_bound_available{false};
   std::string time_to_collision_within_bound_reason{"unavailable"};
   double time_to_collision_infraction_time_s{std::numeric_limits<double>::infinity()};
+  TTCWithinBoundDebugInfo time_to_collision_within_bound_debug;
   double lane_keeping{0.0};
   bool lane_keeping_available{false};
   std::string lane_keeping_reason{"unavailable"};
+  LaneKeepingDebugInfo lane_keeping_debug;
   double ego_progress{0.0};
   bool ego_progress_available{false};
   std::string ego_progress_reason{"unavailable"};
@@ -85,17 +104,21 @@ struct TrajectoryPointMetrics
   double drivable_area_compliance{0.0};
   bool drivable_area_compliance_available{false};
   std::string drivable_area_compliance_reason{"unavailable"};
+  DrivableAreaComplianceDebugInfo drivable_area_compliance_debug;
   double no_at_fault_collision{0.0};
   bool no_at_fault_collision_available{false};
   std::string no_at_fault_collision_reason{"unavailable"};
   double time_to_at_fault_collision_s{std::numeric_limits<double>::infinity()};
+  NoAtFaultCollisionDebugInfo no_at_fault_collision_debug;
   double driving_direction_compliance{0.0};
   bool driving_direction_compliance_available{false};
   std::string driving_direction_compliance_reason{"unavailable"};
   double max_oncoming_progress_m{0.0};
+  DrivingDirectionComplianceDebugInfo driving_direction_compliance_debug;
   double traffic_light_compliance{0.0};
   bool traffic_light_compliance_available{false};
   std::string traffic_light_compliance_reason{"unavailable"};
+  TrafficLightComplianceDebugInfo traffic_light_compliance_debug;
 };
 
 /**
@@ -113,7 +136,9 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     DrivingDirectionComplianceParameters{},
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info =
     autoware::vehicle_info_utils::VehicleInfo{},
-  const std::vector<TimedTrackedObjects> & future_objects = {});
+  const std::vector<TimedTrackedObjects> & future_objects = {},
+  const TrajectoryMetricDebugEnabledMetrics & debug_enabled_metrics =
+    TrajectoryMetricDebugEnabledMetrics{});
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -649,12 +649,8 @@ void OpenLoopEvaluator::evaluate(
         const auto agent_snapshot = build_epdms_snapshot(metrics);
         human_filter_metrics_list_[i] =
           metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
-        if (enabled_metrics_.enable_epdms_calculation) {
-          synthetic_epdms_metrics_list_[i] =
-            metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
-        } else {
-          synthetic_epdms_metrics_list_[i] = metrics::SyntheticEpdmsMetrics{};
-        }
+        synthetic_epdms_metrics_list_[i] =
+          metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
 
         const auto processed = phase2_processed.fetch_add(1U) + 1U;
         if (processed % kProgressLogInterval == 0U || processed == total_samples) {

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -15,15 +15,17 @@
 #include "open_loop_evaluator.hpp"
 
 #include "metrics/epdms/aggregation/epdms_aggregation.hpp"
+#include "metrics/epdms/debug/epdms_debug_writer.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 #include "metrics/geometry/object_tracks.hpp"
+#include "metrics/geometry/trajectory_utils.hpp"
 #include "metrics/metric_types.hpp"
 #include "metrics/trajectory_metrics.hpp"
 
 #include <autoware/motion_utils/trajectory/conversion.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
+#include <rclcpp/duration.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rosbag2_cpp/reader.hpp>
 
@@ -147,78 +149,6 @@ std::shared_ptr<SynchronizedData> clone_with_trajectory(
   return cloned;
 }
 
-double point_time_s(const autoware_planning_msgs::msg::TrajectoryPoint & point)
-{
-  return rclcpp::Duration(point.time_from_start).seconds();
-}
-
-double lerp(const double lhs, const double rhs, const double ratio)
-{
-  return lhs + (rhs - lhs) * ratio;
-}
-
-autoware_planning_msgs::msg::TrajectoryPoint interpolate_trajectory_point(
-  const autoware_planning_msgs::msg::TrajectoryPoint & previous,
-  const autoware_planning_msgs::msg::TrajectoryPoint & next, const double horizon_s)
-{
-  const double previous_t = point_time_s(previous);
-  const double next_t = point_time_s(next);
-  const double ratio = next_t > previous_t
-                         ? std::clamp((horizon_s - previous_t) / (next_t - previous_t), 0.0, 1.0)
-                         : 0.0;
-
-  auto interpolated = previous;
-  interpolated.pose =
-    autoware_utils_geometry::calc_interpolated_pose(previous.pose, next.pose, ratio);
-  interpolated.longitudinal_velocity_mps =
-    lerp(previous.longitudinal_velocity_mps, next.longitudinal_velocity_mps, ratio);
-  interpolated.lateral_velocity_mps =
-    lerp(previous.lateral_velocity_mps, next.lateral_velocity_mps, ratio);
-  interpolated.acceleration_mps2 = lerp(previous.acceleration_mps2, next.acceleration_mps2, ratio);
-  interpolated.heading_rate_rps = lerp(previous.heading_rate_rps, next.heading_rate_rps, ratio);
-  interpolated.front_wheel_angle_rad =
-    lerp(previous.front_wheel_angle_rad, next.front_wheel_angle_rad, ratio);
-  interpolated.rear_wheel_angle_rad =
-    lerp(previous.rear_wheel_angle_rad, next.rear_wheel_angle_rad, ratio);
-  interpolated.time_from_start = rclcpp::Duration::from_seconds(horizon_s);
-  return interpolated;
-}
-
-autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
-  const autoware_planning_msgs::msg::Trajectory & trajectory, const double horizon_s)
-{
-  constexpr double kTimeEpsilon = 1.0e-6;
-  if (horizon_s <= 0.0 || trajectory.points.empty()) {
-    return trajectory;
-  }
-
-  autoware_planning_msgs::msg::Trajectory truncated;
-  truncated.header = trajectory.header;
-  truncated.points.reserve(trajectory.points.size());
-
-  for (const auto & point : trajectory.points) {
-    const double t = point_time_s(point);
-    if (t <= horizon_s + kTimeEpsilon) {
-      truncated.points.push_back(point);
-      continue;
-    }
-
-    if (!truncated.points.empty()) {
-      const double previous_t = point_time_s(truncated.points.back());
-      if (previous_t < horizon_s - kTimeEpsilon) {
-        truncated.points.push_back(
-          interpolate_trajectory_point(truncated.points.back(), point, horizon_s));
-      }
-    }
-    if (truncated.points.empty()) {
-      truncated.points.push_back(point);
-    }
-    return truncated;
-  }
-
-  return truncated;
-}
-
 metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetrics & metrics)
 {
   metrics::EpdmsMetricSnapshot snapshot;
@@ -316,6 +246,22 @@ metrics::EpdmsMetricSnapshot calculate_human_reference_snapshot(
   human_snapshot.traffic_light_compliance_available =
     human_point_metrics.traffic_light_compliance_available;
   return human_snapshot;
+}
+
+metrics::EpdmsDebugEnabledMetrics make_epdms_debug_enabled_metrics(
+  const EnabledOpenLoopMetrics & enabled_metrics)
+{
+  metrics::EpdmsDebugEnabledMetrics enabled;
+  enabled.history_comfort = enabled_metrics.history_comfort;
+  enabled.extended_comfort = enabled_metrics.extended_comfort;
+  enabled.time_to_collision_within_bound = enabled_metrics.time_to_collision_within_bound;
+  enabled.lane_keeping = enabled_metrics.lane_keeping;
+  enabled.ego_progress = enabled_metrics.ego_progress;
+  enabled.drivable_area_compliance = enabled_metrics.drivable_area_compliance;
+  enabled.no_at_fault_collision = enabled_metrics.no_at_fault_collision;
+  enabled.driving_direction_compliance = enabled_metrics.driving_direction_compliance;
+  enabled.traffic_light_compliance = enabled_metrics.traffic_light_compliance;
+  return enabled;
 }
 
 }  // namespace
@@ -528,9 +474,17 @@ void OpenLoopEvaluator::evaluate(
                 *eval_data.synchronized_data->trajectory, object_timeline_,
                 trajectory_evaluation_horizon_s_)
             : std::vector<TimedTrackedObjects>{};
+        const metrics::TrajectoryMetricDebugEnabledMetrics debug_enabled_metrics{
+          debug_topics_enabled_ && enabled_metrics_.time_to_collision_within_bound,
+          debug_topics_enabled_ && enabled_metrics_.no_at_fault_collision,
+          debug_topics_enabled_ && enabled_metrics_.drivable_area_compliance,
+          debug_topics_enabled_ && enabled_metrics_.lane_keeping,
+          debug_topics_enabled_ && enabled_metrics_.driving_direction_compliance,
+          debug_topics_enabled_ && enabled_metrics_.traffic_light_compliance};
         auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
           eval_data.synchronized_data, route_handler_, history_comfort_params_,
-          lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects);
+          lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects,
+          debug_enabled_metrics);
         auto metrics = evaluate_trajectory(eval_data);
         metrics.history_comfort = trajectory_metrics.history_comfort;
         metrics.history_comfort_available = trajectory_metrics.history_comfort_available;
@@ -655,6 +609,13 @@ void OpenLoopEvaluator::evaluate(
             metrics.extended_comfort = extended_comfort_result.score;
             metrics.extended_comfort_available = extended_comfort_result.available;
             metrics.extended_comfort_reason = extended_comfort_result.reason;
+            metrics.extended_comfort_debug_summary = extended_comfort_result.debug_summary;
+            metrics.extended_comfort_sample_times = extended_comfort_result.sample_times;
+            metrics.extended_comfort_delta_acceleration =
+              extended_comfort_result.delta_acceleration;
+            metrics.extended_comfort_delta_jerk = extended_comfort_result.delta_jerk;
+            metrics.extended_comfort_delta_yaw_rate = extended_comfort_result.delta_yaw_rate;
+            metrics.extended_comfort_delta_yaw_accel = extended_comfort_result.delta_yaw_accel;
           }
         }
 
@@ -737,7 +698,7 @@ std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evalua
     }
 
     const auto truncated_trajectory =
-      truncate_trajectory_by_horizon(*data->trajectory, trajectory_evaluation_horizon_s_);
+      metrics::truncate_trajectory_by_horizon(*data->trajectory, trajectory_evaluation_horizon_s_);
     const auto truncated_data = clone_with_trajectory(data, truncated_trajectory);
 
     const size_t num_pts = truncated_data->trajectory->points.size();
@@ -1464,6 +1425,19 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   if (!gt_traj_msg.points.empty()) {
     bag_writer.write(gt_traj_msg, compared_trajectory_topic(), message_timestamp);
   }
+
+  if (debug_topics_enabled_) {
+    metrics::write_epdms_trajectory_horizon_debug_topics_to_bag(
+      *trajectory_data->trajectory, ground_truth_trajectory, vehicle_info_, bag_writer,
+      message_timestamp);
+    if (enabled_metrics_.extended_comfort) {
+      metrics::write_epdms_extended_comfort_debug_topics_to_bag(
+        metrics.extended_comfort_debug_summary, metrics.extended_comfort_sample_times,
+        metrics.extended_comfort_delta_acceleration, metrics.extended_comfort_delta_jerk,
+        metrics.extended_comfort_delta_yaw_rate, metrics.extended_comfort_delta_yaw_accel,
+        bag_writer, message_timestamp);
+    }
+  }
 }
 
 void OpenLoopEvaluator::save_trajectory_point_metrics_to_bag_with_variant(
@@ -1509,6 +1483,12 @@ void OpenLoopEvaluator::save_trajectory_point_metrics_to_bag_with_variant(
   write_array(
     enabled_metrics_.ego_progress, metrics.travel_distances,
     trajectory_metric_topic("travel_distances"));
+
+  if (debug_topics_enabled_) {
+    metrics::write_epdms_point_debug_topics_to_bag(
+      metrics, make_epdms_debug_enabled_metrics(enabled_metrics_), history_comfort_params_,
+      vehicle_info_, bag_writer, normalized_timestamp);
+  }
 }
 
 std::string OpenLoopEvaluator::metric_topic(const std::string & metric_name) const
@@ -2410,6 +2390,10 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     "/perception/object_recognition/objects", "autoware_perception_msgs/msg/PredictedObjects");
   add_topic("/tf", "tf2_msgs/msg/TFMessage");
   add_topic("/tf_static", "tf2_msgs/msg/TFMessage");
+  if (debug_topics_enabled_) {
+    metrics::add_epdms_debug_result_topics(
+      topics, make_epdms_debug_enabled_metrics(enabled_metrics_));
+  }
   return topics;
 }
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -1684,351 +1684,356 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
       tag, "min_ttc", "Minimum Time To Collision within " + tag + " horizon [s]", min_ttc_vals);
   }
 
-  std::vector<double> history_comfort_values;
-  history_comfort_values.reserve(metrics_list_.size());
-  std::size_t history_comfort_available_count = 0;
-  std::map<std::string, std::size_t> history_comfort_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++history_comfort_reason_counts[m.history_comfort_reason];
-    if (m.history_comfort_available) {
-      history_comfort_values.push_back(m.history_comfort);
-      ++history_comfort_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "history_comfort", "Binary history comfort subscore across trajectories [-]",
-    history_comfort_values);
-  j["aggregate/history_comfort_available_count"] = history_comfort_available_count;
-  j["aggregate/history_comfort_unavailable_count"] =
-    metrics_list_.size() - history_comfort_available_count;
-  j["aggregate/history_comfort_reason_counts"] = history_comfort_reason_counts;
-  std::vector<double> extended_comfort_values;
-  extended_comfort_values.reserve(metrics_list_.size());
-  std::size_t extended_comfort_available_count = 0;
-  std::map<std::string, std::size_t> extended_comfort_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++extended_comfort_reason_counts[m.extended_comfort_reason];
-    if (m.extended_comfort_available) {
-      extended_comfort_values.push_back(m.extended_comfort);
-      ++extended_comfort_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "extended_comfort",
-    "Binary extended comfort subscore across consecutive trajectories [-]",
-    extended_comfort_values);
-  j["aggregate/extended_comfort_available_count"] = extended_comfort_available_count;
-  j["aggregate/extended_comfort_unavailable_count"] =
-    metrics_list_.size() - extended_comfort_available_count;
-  j["aggregate/extended_comfort_reason_counts"] = extended_comfort_reason_counts;
-  std::vector<double> time_to_collision_within_bound_values;
-  time_to_collision_within_bound_values.reserve(metrics_list_.size());
-  std::size_t time_to_collision_within_bound_available_count = 0;
-  std::map<std::string, std::size_t> time_to_collision_within_bound_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++time_to_collision_within_bound_reason_counts[m.time_to_collision_within_bound_reason];
-    if (m.time_to_collision_within_bound_available) {
-      time_to_collision_within_bound_values.push_back(m.time_to_collision_within_bound);
-      ++time_to_collision_within_bound_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "time_to_collision_within_bound",
-    "Binary TTC-within-bound subscore across trajectories [-]",
-    time_to_collision_within_bound_values);
-  j["aggregate/time_to_collision_within_bound_available_count"] =
-    time_to_collision_within_bound_available_count;
-  j["aggregate/time_to_collision_within_bound_unavailable_count"] =
-    metrics_list_.size() - time_to_collision_within_bound_available_count;
-  j["aggregate/time_to_collision_within_bound_reason_counts"] =
-    time_to_collision_within_bound_reason_counts;
-  std::vector<double> lane_keeping_values;
-  lane_keeping_values.reserve(metrics_list_.size());
-  std::size_t lane_keeping_available_count = 0;
-  std::map<std::string, std::size_t> lane_keeping_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++lane_keeping_reason_counts[m.lane_keeping_reason];
-    if (m.lane_keeping_available) {
-      lane_keeping_values.push_back(m.lane_keeping);
-      ++lane_keeping_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "lane_keeping", "Binary lane keeping subscore across trajectories [-]",
-    lane_keeping_values);
-  j["aggregate/lane_keeping_available_count"] = lane_keeping_available_count;
-  j["aggregate/lane_keeping_unavailable_count"] =
-    metrics_list_.size() - lane_keeping_available_count;
-  j["aggregate/lane_keeping_reason_counts"] = lane_keeping_reason_counts;
-  std::vector<double> ego_progress_values;
-  ego_progress_values.reserve(metrics_list_.size());
-  std::size_t ego_progress_available_count = 0;
-  std::map<std::string, std::size_t> ego_progress_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++ego_progress_reason_counts[m.ego_progress_reason];
-    if (m.ego_progress_available) {
-      ego_progress_values.push_back(m.ego_progress);
-      ++ego_progress_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "ego_progress", "Proposal-relative ego progress subscore across trajectories [-]",
-    ego_progress_values);
-  j["aggregate/ego_progress_available_count"] = ego_progress_available_count;
-  j["aggregate/ego_progress_unavailable_count"] =
-    metrics_list_.size() - ego_progress_available_count;
-  j["aggregate/ego_progress_reason_counts"] = ego_progress_reason_counts;
-  std::vector<double> drivable_area_compliance_values;
-  drivable_area_compliance_values.reserve(metrics_list_.size());
-  std::size_t drivable_area_compliance_available_count = 0;
-  std::map<std::string, std::size_t> drivable_area_compliance_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++drivable_area_compliance_reason_counts[m.drivable_area_compliance_reason];
-    if (m.drivable_area_compliance_available) {
-      drivable_area_compliance_values.push_back(m.drivable_area_compliance);
-      ++drivable_area_compliance_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "drivable_area_compliance",
-    "Binary drivable area compliance subscore across trajectories [-]",
-    drivable_area_compliance_values);
-  j["aggregate/drivable_area_compliance_available_count"] =
-    drivable_area_compliance_available_count;
-  j["aggregate/drivable_area_compliance_unavailable_count"] =
-    metrics_list_.size() - drivable_area_compliance_available_count;
-  j["aggregate/drivable_area_compliance_reason_counts"] = drivable_area_compliance_reason_counts;
-  std::vector<double> no_at_fault_collision_values;
-  std::vector<double> time_to_at_fault_collision_values;
-  no_at_fault_collision_values.reserve(metrics_list_.size());
-  time_to_at_fault_collision_values.reserve(metrics_list_.size());
-  std::size_t no_at_fault_collision_available_count = 0;
-  std::map<std::string, std::size_t> no_at_fault_collision_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++no_at_fault_collision_reason_counts[m.no_at_fault_collision_reason];
-    if (m.no_at_fault_collision_available) {
-      no_at_fault_collision_values.push_back(m.no_at_fault_collision);
-      ++no_at_fault_collision_available_count;
-      if (std::isfinite(m.time_to_at_fault_collision_s)) {
-        time_to_at_fault_collision_values.push_back(m.time_to_at_fault_collision_s);
+  if (enabled_metrics_.enable_epdms_calculation) {
+    std::vector<double> history_comfort_values;
+    history_comfort_values.reserve(metrics_list_.size());
+    std::size_t history_comfort_available_count = 0;
+    std::map<std::string, std::size_t> history_comfort_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++history_comfort_reason_counts[m.history_comfort_reason];
+      if (m.history_comfort_available) {
+        history_comfort_values.push_back(m.history_comfort);
+        ++history_comfort_available_count;
       }
     }
-  }
-  emit_metric(
-    "aggregate", "no_at_fault_collision",
-    "NAVSIM-style no-at-fault-collision subscore across trajectories [-]",
-    no_at_fault_collision_values);
-  emit_metric(
-    "aggregate", "time_to_at_fault_collision_s",
-    "Time to first at-fault collision across trajectories [s]", time_to_at_fault_collision_values);
-  j["aggregate/no_at_fault_collision_available_count"] = no_at_fault_collision_available_count;
-  j["aggregate/no_at_fault_collision_unavailable_count"] =
-    metrics_list_.size() - no_at_fault_collision_available_count;
-  j["aggregate/no_at_fault_collision_reason_counts"] = no_at_fault_collision_reason_counts;
-  std::vector<double> driving_direction_compliance_values;
-  std::vector<double> max_oncoming_progress_values;
-  driving_direction_compliance_values.reserve(metrics_list_.size());
-  max_oncoming_progress_values.reserve(metrics_list_.size());
-  std::size_t driving_direction_compliance_available_count = 0;
-  std::map<std::string, std::size_t> driving_direction_compliance_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++driving_direction_compliance_reason_counts[m.driving_direction_compliance_reason];
-    if (m.driving_direction_compliance_available) {
-      driving_direction_compliance_values.push_back(m.driving_direction_compliance);
-      max_oncoming_progress_values.push_back(m.max_oncoming_progress_m);
-      ++driving_direction_compliance_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "driving_direction_compliance",
-    "NAVSIM-style driving direction compliance subscore across trajectories [-]",
-    driving_direction_compliance_values);
-  emit_metric(
-    "aggregate", "max_oncoming_progress_m",
-    "Maximum rolling 1s oncoming progress across trajectories [m]", max_oncoming_progress_values);
-  j["aggregate/driving_direction_compliance_available_count"] =
-    driving_direction_compliance_available_count;
-  j["aggregate/driving_direction_compliance_unavailable_count"] =
-    metrics_list_.size() - driving_direction_compliance_available_count;
-  j["aggregate/driving_direction_compliance_reason_counts"] =
-    driving_direction_compliance_reason_counts;
-  std::vector<double> traffic_light_compliance_values;
-  traffic_light_compliance_values.reserve(metrics_list_.size());
-  std::size_t traffic_light_compliance_available_count = 0;
-  std::map<std::string, std::size_t> traffic_light_compliance_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++traffic_light_compliance_reason_counts[m.traffic_light_compliance_reason];
-    if (m.traffic_light_compliance_available) {
-      traffic_light_compliance_values.push_back(m.traffic_light_compliance);
-      ++traffic_light_compliance_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "traffic_light_compliance",
-    "Binary traffic light compliance subscore across trajectories [-]",
-    traffic_light_compliance_values);
-  j["aggregate/traffic_light_compliance_available_count"] =
-    traffic_light_compliance_available_count;
-  j["aggregate/traffic_light_compliance_unavailable_count"] =
-    metrics_list_.size() - traffic_light_compliance_available_count;
-  j["aggregate/traffic_light_compliance_reason_counts"] = traffic_light_compliance_reason_counts;
-
-  auto emit_human_filter_metric = [&](
-                                    const std::string & metric_name, const std::string & desc,
-                                    const std::vector<double> & human_vals,
-                                    const std::vector<double> & filtered_vals,
-                                    const std::size_t applied_count) {
     emit_metric(
-      "aggregate/human_reference", metric_name, "Human reference " + desc + " [-]", human_vals);
+      "aggregate", "history_comfort", "Binary history comfort subscore across trajectories [-]",
+      history_comfort_values);
+    j["aggregate/history_comfort_available_count"] = history_comfort_available_count;
+    j["aggregate/history_comfort_unavailable_count"] =
+      metrics_list_.size() - history_comfort_available_count;
+    j["aggregate/history_comfort_reason_counts"] = history_comfort_reason_counts;
+    std::vector<double> extended_comfort_values;
+    extended_comfort_values.reserve(metrics_list_.size());
+    std::size_t extended_comfort_available_count = 0;
+    std::map<std::string, std::size_t> extended_comfort_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++extended_comfort_reason_counts[m.extended_comfort_reason];
+      if (m.extended_comfort_available) {
+        extended_comfort_values.push_back(m.extended_comfort);
+        ++extended_comfort_available_count;
+      }
+    }
     emit_metric(
-      "aggregate/human_filtered", metric_name, "Human-filtered " + desc + " [-]", filtered_vals);
-    j["aggregate/human_filter_applied_counts/" + metric_name] = applied_count;
-  };
+      "aggregate", "extended_comfort",
+      "Binary extended comfort subscore across consecutive trajectories [-]",
+      extended_comfort_values);
+    j["aggregate/extended_comfort_available_count"] = extended_comfort_available_count;
+    j["aggregate/extended_comfort_unavailable_count"] =
+      metrics_list_.size() - extended_comfort_available_count;
+    j["aggregate/extended_comfort_reason_counts"] = extended_comfort_reason_counts;
+    std::vector<double> time_to_collision_within_bound_values;
+    time_to_collision_within_bound_values.reserve(metrics_list_.size());
+    std::size_t time_to_collision_within_bound_available_count = 0;
+    std::map<std::string, std::size_t> time_to_collision_within_bound_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++time_to_collision_within_bound_reason_counts[m.time_to_collision_within_bound_reason];
+      if (m.time_to_collision_within_bound_available) {
+        time_to_collision_within_bound_values.push_back(m.time_to_collision_within_bound);
+        ++time_to_collision_within_bound_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "time_to_collision_within_bound",
+      "Binary TTC-within-bound subscore across trajectories [-]",
+      time_to_collision_within_bound_values);
+    j["aggregate/time_to_collision_within_bound_available_count"] =
+      time_to_collision_within_bound_available_count;
+    j["aggregate/time_to_collision_within_bound_unavailable_count"] =
+      metrics_list_.size() - time_to_collision_within_bound_available_count;
+    j["aggregate/time_to_collision_within_bound_reason_counts"] =
+      time_to_collision_within_bound_reason_counts;
+    std::vector<double> lane_keeping_values;
+    lane_keeping_values.reserve(metrics_list_.size());
+    std::size_t lane_keeping_available_count = 0;
+    std::map<std::string, std::size_t> lane_keeping_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++lane_keeping_reason_counts[m.lane_keeping_reason];
+      if (m.lane_keeping_available) {
+        lane_keeping_values.push_back(m.lane_keeping);
+        ++lane_keeping_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "lane_keeping", "Binary lane keeping subscore across trajectories [-]",
+      lane_keeping_values);
+    j["aggregate/lane_keeping_available_count"] = lane_keeping_available_count;
+    j["aggregate/lane_keeping_unavailable_count"] =
+      metrics_list_.size() - lane_keeping_available_count;
+    j["aggregate/lane_keeping_reason_counts"] = lane_keeping_reason_counts;
+    std::vector<double> ego_progress_values;
+    ego_progress_values.reserve(metrics_list_.size());
+    std::size_t ego_progress_available_count = 0;
+    std::map<std::string, std::size_t> ego_progress_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++ego_progress_reason_counts[m.ego_progress_reason];
+      if (m.ego_progress_available) {
+        ego_progress_values.push_back(m.ego_progress);
+        ++ego_progress_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "ego_progress",
+      "Proposal-relative ego progress subscore across trajectories [-]", ego_progress_values);
+    j["aggregate/ego_progress_available_count"] = ego_progress_available_count;
+    j["aggregate/ego_progress_unavailable_count"] =
+      metrics_list_.size() - ego_progress_available_count;
+    j["aggregate/ego_progress_reason_counts"] = ego_progress_reason_counts;
+    std::vector<double> drivable_area_compliance_values;
+    drivable_area_compliance_values.reserve(metrics_list_.size());
+    std::size_t drivable_area_compliance_available_count = 0;
+    std::map<std::string, std::size_t> drivable_area_compliance_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++drivable_area_compliance_reason_counts[m.drivable_area_compliance_reason];
+      if (m.drivable_area_compliance_available) {
+        drivable_area_compliance_values.push_back(m.drivable_area_compliance);
+        ++drivable_area_compliance_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "drivable_area_compliance",
+      "Binary drivable area compliance subscore across trajectories [-]",
+      drivable_area_compliance_values);
+    j["aggregate/drivable_area_compliance_available_count"] =
+      drivable_area_compliance_available_count;
+    j["aggregate/drivable_area_compliance_unavailable_count"] =
+      metrics_list_.size() - drivable_area_compliance_available_count;
+    j["aggregate/drivable_area_compliance_reason_counts"] = drivable_area_compliance_reason_counts;
+    std::vector<double> no_at_fault_collision_values;
+    std::vector<double> time_to_at_fault_collision_values;
+    no_at_fault_collision_values.reserve(metrics_list_.size());
+    time_to_at_fault_collision_values.reserve(metrics_list_.size());
+    std::size_t no_at_fault_collision_available_count = 0;
+    std::map<std::string, std::size_t> no_at_fault_collision_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++no_at_fault_collision_reason_counts[m.no_at_fault_collision_reason];
+      if (m.no_at_fault_collision_available) {
+        no_at_fault_collision_values.push_back(m.no_at_fault_collision);
+        ++no_at_fault_collision_available_count;
+        if (std::isfinite(m.time_to_at_fault_collision_s)) {
+          time_to_at_fault_collision_values.push_back(m.time_to_at_fault_collision_s);
+        }
+      }
+    }
+    emit_metric(
+      "aggregate", "no_at_fault_collision",
+      "NAVSIM-style no-at-fault-collision subscore across trajectories [-]",
+      no_at_fault_collision_values);
+    emit_metric(
+      "aggregate", "time_to_at_fault_collision_s",
+      "Time to first at-fault collision across trajectories [s]",
+      time_to_at_fault_collision_values);
+    j["aggregate/no_at_fault_collision_available_count"] = no_at_fault_collision_available_count;
+    j["aggregate/no_at_fault_collision_unavailable_count"] =
+      metrics_list_.size() - no_at_fault_collision_available_count;
+    j["aggregate/no_at_fault_collision_reason_counts"] = no_at_fault_collision_reason_counts;
+    std::vector<double> driving_direction_compliance_values;
+    std::vector<double> max_oncoming_progress_values;
+    driving_direction_compliance_values.reserve(metrics_list_.size());
+    max_oncoming_progress_values.reserve(metrics_list_.size());
+    std::size_t driving_direction_compliance_available_count = 0;
+    std::map<std::string, std::size_t> driving_direction_compliance_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++driving_direction_compliance_reason_counts[m.driving_direction_compliance_reason];
+      if (m.driving_direction_compliance_available) {
+        driving_direction_compliance_values.push_back(m.driving_direction_compliance);
+        max_oncoming_progress_values.push_back(m.max_oncoming_progress_m);
+        ++driving_direction_compliance_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "driving_direction_compliance",
+      "NAVSIM-style driving direction compliance subscore across trajectories [-]",
+      driving_direction_compliance_values);
+    emit_metric(
+      "aggregate", "max_oncoming_progress_m",
+      "Maximum rolling 1s oncoming progress across trajectories [m]", max_oncoming_progress_values);
+    j["aggregate/driving_direction_compliance_available_count"] =
+      driving_direction_compliance_available_count;
+    j["aggregate/driving_direction_compliance_unavailable_count"] =
+      metrics_list_.size() - driving_direction_compliance_available_count;
+    j["aggregate/driving_direction_compliance_reason_counts"] =
+      driving_direction_compliance_reason_counts;
+    std::vector<double> traffic_light_compliance_values;
+    traffic_light_compliance_values.reserve(metrics_list_.size());
+    std::size_t traffic_light_compliance_available_count = 0;
+    std::map<std::string, std::size_t> traffic_light_compliance_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++traffic_light_compliance_reason_counts[m.traffic_light_compliance_reason];
+      if (m.traffic_light_compliance_available) {
+        traffic_light_compliance_values.push_back(m.traffic_light_compliance);
+        ++traffic_light_compliance_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "traffic_light_compliance",
+      "Binary traffic light compliance subscore across trajectories [-]",
+      traffic_light_compliance_values);
+    j["aggregate/traffic_light_compliance_available_count"] =
+      traffic_light_compliance_available_count;
+    j["aggregate/traffic_light_compliance_unavailable_count"] =
+      metrics_list_.size() - traffic_light_compliance_available_count;
+    j["aggregate/traffic_light_compliance_reason_counts"] = traffic_light_compliance_reason_counts;
 
-  std::vector<double> human_history_comfort_values;
-  std::vector<double> filtered_history_comfort_values;
-  std::size_t history_comfort_filter_applied_count = 0;
-  std::vector<double> human_ego_progress_values;
-  std::vector<double> filtered_ego_progress_values;
-  std::size_t ego_progress_filter_applied_count = 0;
-  std::vector<double> human_ttc_within_bound_values;
-  std::vector<double> filtered_ttc_within_bound_values;
-  std::size_t ttc_within_bound_filter_applied_count = 0;
-  std::vector<double> human_lane_keeping_values;
-  std::vector<double> filtered_lane_keeping_values;
-  std::size_t lane_keeping_filter_applied_count = 0;
-  std::vector<double> human_dac_values;
-  std::vector<double> filtered_dac_values;
-  std::size_t dac_filter_applied_count = 0;
-  std::vector<double> human_nc_values;
-  std::vector<double> filtered_nc_values;
-  std::size_t nc_filter_applied_count = 0;
-  std::vector<double> human_ddc_values;
-  std::vector<double> filtered_ddc_values;
-  std::size_t ddc_filter_applied_count = 0;
-  std::vector<double> human_tlc_values;
-  std::vector<double> filtered_tlc_values;
-  std::size_t tlc_filter_applied_count = 0;
-  for (const auto & m : human_filter_metrics_list_) {
-    if (m.history_comfort.human_reference_available) {
-      human_history_comfort_values.push_back(m.history_comfort.human_reference);
-      filtered_history_comfort_values.push_back(m.history_comfort.filtered);
-    }
-    history_comfort_filter_applied_count +=
-      static_cast<std::size_t>(m.history_comfort.filter_applied);
-    if (m.ego_progress.human_reference_available) {
-      human_ego_progress_values.push_back(m.ego_progress.human_reference);
-      filtered_ego_progress_values.push_back(m.ego_progress.filtered);
-    }
-    ego_progress_filter_applied_count += static_cast<std::size_t>(m.ego_progress.filter_applied);
-    if (m.time_to_collision_within_bound.human_reference_available) {
-      human_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.human_reference);
-      filtered_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.filtered);
-    }
-    ttc_within_bound_filter_applied_count +=
-      static_cast<std::size_t>(m.time_to_collision_within_bound.filter_applied);
-    if (m.lane_keeping.human_reference_available) {
-      human_lane_keeping_values.push_back(m.lane_keeping.human_reference);
-      filtered_lane_keeping_values.push_back(m.lane_keeping.filtered);
-    }
-    lane_keeping_filter_applied_count += static_cast<std::size_t>(m.lane_keeping.filter_applied);
-    if (m.drivable_area_compliance.human_reference_available) {
-      human_dac_values.push_back(m.drivable_area_compliance.human_reference);
-      filtered_dac_values.push_back(m.drivable_area_compliance.filtered);
-    }
-    dac_filter_applied_count += static_cast<std::size_t>(m.drivable_area_compliance.filter_applied);
-    if (m.no_at_fault_collision.human_reference_available) {
-      human_nc_values.push_back(m.no_at_fault_collision.human_reference);
-      filtered_nc_values.push_back(m.no_at_fault_collision.filtered);
-    }
-    nc_filter_applied_count += static_cast<std::size_t>(m.no_at_fault_collision.filter_applied);
-    if (m.driving_direction_compliance.human_reference_available) {
-      human_ddc_values.push_back(m.driving_direction_compliance.human_reference);
-      filtered_ddc_values.push_back(m.driving_direction_compliance.filtered);
-    }
-    ddc_filter_applied_count +=
-      static_cast<std::size_t>(m.driving_direction_compliance.filter_applied);
-    if (m.traffic_light_compliance.human_reference_available) {
-      human_tlc_values.push_back(m.traffic_light_compliance.human_reference);
-      filtered_tlc_values.push_back(m.traffic_light_compliance.filtered);
-    }
-    tlc_filter_applied_count += static_cast<std::size_t>(m.traffic_light_compliance.filter_applied);
-  }
-  emit_human_filter_metric(
-    "history_comfort", "history comfort subscore", human_history_comfort_values,
-    filtered_history_comfort_values, history_comfort_filter_applied_count);
-  emit_human_filter_metric(
-    "ego_progress", "ego progress subscore", human_ego_progress_values,
-    filtered_ego_progress_values, ego_progress_filter_applied_count);
-  emit_human_filter_metric(
-    "time_to_collision_within_bound", "TTC-within-bound subscore", human_ttc_within_bound_values,
-    filtered_ttc_within_bound_values, ttc_within_bound_filter_applied_count);
-  emit_human_filter_metric(
-    "lane_keeping", "lane keeping subscore", human_lane_keeping_values,
-    filtered_lane_keeping_values, lane_keeping_filter_applied_count);
-  emit_human_filter_metric(
-    "drivable_area_compliance", "drivable area compliance subscore", human_dac_values,
-    filtered_dac_values, dac_filter_applied_count);
-  emit_human_filter_metric(
-    "no_at_fault_collision", "no-at-fault collision subscore", human_nc_values, filtered_nc_values,
-    nc_filter_applied_count);
-  emit_human_filter_metric(
-    "driving_direction_compliance", "driving direction compliance subscore", human_ddc_values,
-    filtered_ddc_values, ddc_filter_applied_count);
-  emit_human_filter_metric(
-    "traffic_light_compliance", "traffic light compliance subscore", human_tlc_values,
-    filtered_tlc_values, tlc_filter_applied_count);
+    auto emit_human_filter_metric = [&](
+                                      const std::string & metric_name, const std::string & desc,
+                                      const std::vector<double> & human_vals,
+                                      const std::vector<double> & filtered_vals,
+                                      const std::size_t applied_count) {
+      emit_metric(
+        "aggregate/human_reference", metric_name, "Human reference " + desc + " [-]", human_vals);
+      emit_metric(
+        "aggregate/human_filtered", metric_name, "Human-filtered " + desc + " [-]", filtered_vals);
+      j["aggregate/human_filter_applied_counts/" + metric_name] = applied_count;
+    };
 
-  std::vector<double> synthetic_raw_prod_values;
-  std::vector<double> synthetic_raw_weighted_values;
-  std::vector<double> synthetic_raw_epdms_values;
-  std::size_t synthetic_raw_available_count = 0;
-  std::vector<double> synthetic_filtered_prod_values;
-  std::vector<double> synthetic_filtered_weighted_values;
-  std::vector<double> synthetic_filtered_epdms_values;
-  std::size_t synthetic_filtered_available_count = 0;
-  for (const auto & m : synthetic_epdms_metrics_list_) {
-    if (m.raw.available) {
-      synthetic_raw_prod_values.push_back(m.raw.multiplicative_metrics_prod);
-      synthetic_raw_weighted_values.push_back(m.raw.weighted_metrics);
-      synthetic_raw_epdms_values.push_back(m.raw.epdms);
-      ++synthetic_raw_available_count;
+    std::vector<double> human_history_comfort_values;
+    std::vector<double> filtered_history_comfort_values;
+    std::size_t history_comfort_filter_applied_count = 0;
+    std::vector<double> human_ego_progress_values;
+    std::vector<double> filtered_ego_progress_values;
+    std::size_t ego_progress_filter_applied_count = 0;
+    std::vector<double> human_ttc_within_bound_values;
+    std::vector<double> filtered_ttc_within_bound_values;
+    std::size_t ttc_within_bound_filter_applied_count = 0;
+    std::vector<double> human_lane_keeping_values;
+    std::vector<double> filtered_lane_keeping_values;
+    std::size_t lane_keeping_filter_applied_count = 0;
+    std::vector<double> human_dac_values;
+    std::vector<double> filtered_dac_values;
+    std::size_t dac_filter_applied_count = 0;
+    std::vector<double> human_nc_values;
+    std::vector<double> filtered_nc_values;
+    std::size_t nc_filter_applied_count = 0;
+    std::vector<double> human_ddc_values;
+    std::vector<double> filtered_ddc_values;
+    std::size_t ddc_filter_applied_count = 0;
+    std::vector<double> human_tlc_values;
+    std::vector<double> filtered_tlc_values;
+    std::size_t tlc_filter_applied_count = 0;
+    for (const auto & m : human_filter_metrics_list_) {
+      if (m.history_comfort.human_reference_available) {
+        human_history_comfort_values.push_back(m.history_comfort.human_reference);
+        filtered_history_comfort_values.push_back(m.history_comfort.filtered);
+      }
+      history_comfort_filter_applied_count +=
+        static_cast<std::size_t>(m.history_comfort.filter_applied);
+      if (m.ego_progress.human_reference_available) {
+        human_ego_progress_values.push_back(m.ego_progress.human_reference);
+        filtered_ego_progress_values.push_back(m.ego_progress.filtered);
+      }
+      ego_progress_filter_applied_count += static_cast<std::size_t>(m.ego_progress.filter_applied);
+      if (m.time_to_collision_within_bound.human_reference_available) {
+        human_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.human_reference);
+        filtered_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.filtered);
+      }
+      ttc_within_bound_filter_applied_count +=
+        static_cast<std::size_t>(m.time_to_collision_within_bound.filter_applied);
+      if (m.lane_keeping.human_reference_available) {
+        human_lane_keeping_values.push_back(m.lane_keeping.human_reference);
+        filtered_lane_keeping_values.push_back(m.lane_keeping.filtered);
+      }
+      lane_keeping_filter_applied_count += static_cast<std::size_t>(m.lane_keeping.filter_applied);
+      if (m.drivable_area_compliance.human_reference_available) {
+        human_dac_values.push_back(m.drivable_area_compliance.human_reference);
+        filtered_dac_values.push_back(m.drivable_area_compliance.filtered);
+      }
+      dac_filter_applied_count +=
+        static_cast<std::size_t>(m.drivable_area_compliance.filter_applied);
+      if (m.no_at_fault_collision.human_reference_available) {
+        human_nc_values.push_back(m.no_at_fault_collision.human_reference);
+        filtered_nc_values.push_back(m.no_at_fault_collision.filtered);
+      }
+      nc_filter_applied_count += static_cast<std::size_t>(m.no_at_fault_collision.filter_applied);
+      if (m.driving_direction_compliance.human_reference_available) {
+        human_ddc_values.push_back(m.driving_direction_compliance.human_reference);
+        filtered_ddc_values.push_back(m.driving_direction_compliance.filtered);
+      }
+      ddc_filter_applied_count +=
+        static_cast<std::size_t>(m.driving_direction_compliance.filter_applied);
+      if (m.traffic_light_compliance.human_reference_available) {
+        human_tlc_values.push_back(m.traffic_light_compliance.human_reference);
+        filtered_tlc_values.push_back(m.traffic_light_compliance.filtered);
+      }
+      tlc_filter_applied_count +=
+        static_cast<std::size_t>(m.traffic_light_compliance.filter_applied);
     }
-    if (m.human_filtered.available) {
-      synthetic_filtered_prod_values.push_back(m.human_filtered.multiplicative_metrics_prod);
-      synthetic_filtered_weighted_values.push_back(m.human_filtered.weighted_metrics);
-      synthetic_filtered_epdms_values.push_back(m.human_filtered.epdms);
-      ++synthetic_filtered_available_count;
+    emit_human_filter_metric(
+      "history_comfort", "history comfort subscore", human_history_comfort_values,
+      filtered_history_comfort_values, history_comfort_filter_applied_count);
+    emit_human_filter_metric(
+      "ego_progress", "ego progress subscore", human_ego_progress_values,
+      filtered_ego_progress_values, ego_progress_filter_applied_count);
+    emit_human_filter_metric(
+      "time_to_collision_within_bound", "TTC-within-bound subscore", human_ttc_within_bound_values,
+      filtered_ttc_within_bound_values, ttc_within_bound_filter_applied_count);
+    emit_human_filter_metric(
+      "lane_keeping", "lane keeping subscore", human_lane_keeping_values,
+      filtered_lane_keeping_values, lane_keeping_filter_applied_count);
+    emit_human_filter_metric(
+      "drivable_area_compliance", "drivable area compliance subscore", human_dac_values,
+      filtered_dac_values, dac_filter_applied_count);
+    emit_human_filter_metric(
+      "no_at_fault_collision", "no-at-fault collision subscore", human_nc_values,
+      filtered_nc_values, nc_filter_applied_count);
+    emit_human_filter_metric(
+      "driving_direction_compliance", "driving direction compliance subscore", human_ddc_values,
+      filtered_ddc_values, ddc_filter_applied_count);
+    emit_human_filter_metric(
+      "traffic_light_compliance", "traffic light compliance subscore", human_tlc_values,
+      filtered_tlc_values, tlc_filter_applied_count);
+
+    std::vector<double> synthetic_raw_prod_values;
+    std::vector<double> synthetic_raw_weighted_values;
+    std::vector<double> synthetic_raw_epdms_values;
+    std::size_t synthetic_raw_available_count = 0;
+    std::vector<double> synthetic_filtered_prod_values;
+    std::vector<double> synthetic_filtered_weighted_values;
+    std::vector<double> synthetic_filtered_epdms_values;
+    std::size_t synthetic_filtered_available_count = 0;
+    for (const auto & m : synthetic_epdms_metrics_list_) {
+      if (m.raw.available) {
+        synthetic_raw_prod_values.push_back(m.raw.multiplicative_metrics_prod);
+        synthetic_raw_weighted_values.push_back(m.raw.weighted_metrics);
+        synthetic_raw_epdms_values.push_back(m.raw.epdms);
+        ++synthetic_raw_available_count;
+      }
+      if (m.human_filtered.available) {
+        synthetic_filtered_prod_values.push_back(m.human_filtered.multiplicative_metrics_prod);
+        synthetic_filtered_weighted_values.push_back(m.human_filtered.weighted_metrics);
+        synthetic_filtered_epdms_values.push_back(m.human_filtered.epdms);
+        ++synthetic_filtered_available_count;
+      }
     }
+    emit_metric(
+      "aggregate/synthetic_epdms", "raw_multiplicative_metrics_prod",
+      "Synthetic EPDMS multiplicative product across trajectories [-]", synthetic_raw_prod_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "raw_weighted_metrics",
+      "Synthetic EPDMS weighted score across trajectories [-]", synthetic_raw_weighted_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "raw", "Synthetic EPDMS score across trajectories [-]",
+      synthetic_raw_epdms_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "human_filtered_multiplicative_metrics_prod",
+      "Human-filtered synthetic EPDMS multiplicative product across trajectories [-]",
+      synthetic_filtered_prod_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "human_filtered_weighted_metrics",
+      "Human-filtered synthetic EPDMS weighted score across trajectories [-]",
+      synthetic_filtered_weighted_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "human_filtered",
+      "Human-filtered synthetic EPDMS score across trajectories [-]",
+      synthetic_filtered_epdms_values);
+    j["aggregate/synthetic_epdms/raw_available_count"] = synthetic_raw_available_count;
+    j["aggregate/synthetic_epdms/raw_unavailable_count"] =
+      synthetic_epdms_metrics_list_.size() - synthetic_raw_available_count;
+    j["aggregate/synthetic_epdms/human_filtered_available_count"] =
+      synthetic_filtered_available_count;
+    j["aggregate/synthetic_epdms/human_filtered_unavailable_count"] =
+      synthetic_epdms_metrics_list_.size() - synthetic_filtered_available_count;
   }
-  emit_metric(
-    "aggregate/synthetic_epdms", "raw_multiplicative_metrics_prod",
-    "Synthetic EPDMS multiplicative product across trajectories [-]", synthetic_raw_prod_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "raw_weighted_metrics",
-    "Synthetic EPDMS weighted score across trajectories [-]", synthetic_raw_weighted_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "raw", "Synthetic EPDMS score across trajectories [-]",
-    synthetic_raw_epdms_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "human_filtered_multiplicative_metrics_prod",
-    "Human-filtered synthetic EPDMS multiplicative product across trajectories [-]",
-    synthetic_filtered_prod_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "human_filtered_weighted_metrics",
-    "Human-filtered synthetic EPDMS weighted score across trajectories [-]",
-    synthetic_filtered_weighted_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "human_filtered",
-    "Human-filtered synthetic EPDMS score across trajectories [-]",
-    synthetic_filtered_epdms_values);
-  j["aggregate/synthetic_epdms/raw_available_count"] = synthetic_raw_available_count;
-  j["aggregate/synthetic_epdms/raw_unavailable_count"] =
-    synthetic_epdms_metrics_list_.size() - synthetic_raw_available_count;
-  j["aggregate/synthetic_epdms/human_filtered_available_count"] =
-    synthetic_filtered_available_count;
-  j["aggregate/synthetic_epdms/human_filtered_unavailable_count"] =
-    synthetic_epdms_metrics_list_.size() - synthetic_filtered_available_count;
 
   // ----- override_only aggregation -----
   // Re-aggregate per-horizon ADE/FDE (plus the rest of the horizon metrics for symmetry)
@@ -2128,112 +2133,117 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
     traj["lateral_deviations"] = m.lateral_deviations;
     traj["longitudinal_deviations"] = m.longitudinal_deviations;
     traj["ttc"] = m.ttc;
-    traj["history_comfort"] = m.history_comfort;
-    traj["history_comfort_available"] = m.history_comfort_available;
-    traj["history_comfort_reason"] = m.history_comfort_reason;
-    traj["extended_comfort"] = m.extended_comfort;
-    traj["extended_comfort_available"] = m.extended_comfort_available;
-    traj["extended_comfort_reason"] = m.extended_comfort_reason;
-    traj["time_to_collision_within_bound"] = m.time_to_collision_within_bound;
-    traj["time_to_collision_within_bound_available"] = m.time_to_collision_within_bound_available;
-    traj["time_to_collision_within_bound_reason"] = m.time_to_collision_within_bound_reason;
-    traj["time_to_collision_infraction_time_s"] = m.time_to_collision_infraction_time_s;
-    traj["lane_keeping"] = m.lane_keeping;
-    traj["lane_keeping_available"] = m.lane_keeping_available;
-    traj["lane_keeping_reason"] = m.lane_keeping_reason;
-    traj["ego_progress"] = m.ego_progress;
-    traj["ego_progress_available"] = m.ego_progress_available;
-    traj["ego_progress_reason"] = m.ego_progress_reason;
-    traj["ego_progress_raw_m"] = m.ego_progress_raw_m;
-    traj["ego_progress_best_raw_m"] = m.ego_progress_best_raw_m;
-    traj["ego_progress_multiplicative_mask"] = m.ego_progress_mask;
-    traj["ego_progress_denominator_m"] = m.ego_progress_denominator_m;
-    traj["drivable_area_compliance"] = m.drivable_area_compliance;
-    traj["drivable_area_compliance_available"] = m.drivable_area_compliance_available;
-    traj["drivable_area_compliance_reason"] = m.drivable_area_compliance_reason;
-    traj["no_at_fault_collision"] = m.no_at_fault_collision;
-    traj["no_at_fault_collision_available"] = m.no_at_fault_collision_available;
-    traj["no_at_fault_collision_reason"] = m.no_at_fault_collision_reason;
-    traj["time_to_at_fault_collision_s"] = m.time_to_at_fault_collision_s;
-    traj["driving_direction_compliance"] = m.driving_direction_compliance;
-    traj["driving_direction_compliance_available"] = m.driving_direction_compliance_available;
-    traj["driving_direction_compliance_reason"] = m.driving_direction_compliance_reason;
-    traj["max_oncoming_progress_m"] = m.max_oncoming_progress_m;
-    traj["traffic_light_compliance"] = m.traffic_light_compliance;
-    traj["traffic_light_compliance_available"] = m.traffic_light_compliance_available;
-    traj["traffic_light_compliance_reason"] = m.traffic_light_compliance_reason;
-    if (i < human_filter_metrics_list_.size()) {
-      const auto & hf = human_filter_metrics_list_[i];
-      traj["human_reference"]["history_comfort"] = hf.history_comfort.human_reference;
-      traj["human_reference"]["history_comfort_available"] =
-        hf.history_comfort.human_reference_available;
-      traj["human_reference"]["ego_progress"] = hf.ego_progress.human_reference;
-      traj["human_reference"]["ego_progress_available"] = hf.ego_progress.human_reference_available;
-      traj["human_reference"]["time_to_collision_within_bound"] =
-        hf.time_to_collision_within_bound.human_reference;
-      traj["human_reference"]["time_to_collision_within_bound_available"] =
-        hf.time_to_collision_within_bound.human_reference_available;
-      traj["human_reference"]["lane_keeping"] = hf.lane_keeping.human_reference;
-      traj["human_reference"]["lane_keeping_available"] = hf.lane_keeping.human_reference_available;
-      traj["human_reference"]["drivable_area_compliance"] =
-        hf.drivable_area_compliance.human_reference;
-      traj["human_reference"]["drivable_area_compliance_available"] =
-        hf.drivable_area_compliance.human_reference_available;
-      traj["human_reference"]["no_at_fault_collision"] = hf.no_at_fault_collision.human_reference;
-      traj["human_reference"]["no_at_fault_collision_available"] =
-        hf.no_at_fault_collision.human_reference_available;
-      traj["human_reference"]["driving_direction_compliance"] =
-        hf.driving_direction_compliance.human_reference;
-      traj["human_reference"]["driving_direction_compliance_available"] =
-        hf.driving_direction_compliance.human_reference_available;
-      traj["human_reference"]["traffic_light_compliance"] =
-        hf.traffic_light_compliance.human_reference;
-      traj["human_reference"]["traffic_light_compliance_available"] =
-        hf.traffic_light_compliance.human_reference_available;
+    if (enabled_metrics_.enable_epdms_calculation) {
+      traj["history_comfort"] = m.history_comfort;
+      traj["history_comfort_available"] = m.history_comfort_available;
+      traj["history_comfort_reason"] = m.history_comfort_reason;
+      traj["extended_comfort"] = m.extended_comfort;
+      traj["extended_comfort_available"] = m.extended_comfort_available;
+      traj["extended_comfort_reason"] = m.extended_comfort_reason;
+      traj["time_to_collision_within_bound"] = m.time_to_collision_within_bound;
+      traj["time_to_collision_within_bound_available"] = m.time_to_collision_within_bound_available;
+      traj["time_to_collision_within_bound_reason"] = m.time_to_collision_within_bound_reason;
+      traj["time_to_collision_infraction_time_s"] = m.time_to_collision_infraction_time_s;
+      traj["lane_keeping"] = m.lane_keeping;
+      traj["lane_keeping_available"] = m.lane_keeping_available;
+      traj["lane_keeping_reason"] = m.lane_keeping_reason;
+      traj["ego_progress"] = m.ego_progress;
+      traj["ego_progress_available"] = m.ego_progress_available;
+      traj["ego_progress_reason"] = m.ego_progress_reason;
+      traj["ego_progress_raw_m"] = m.ego_progress_raw_m;
+      traj["ego_progress_best_raw_m"] = m.ego_progress_best_raw_m;
+      traj["ego_progress_multiplicative_mask"] = m.ego_progress_mask;
+      traj["ego_progress_denominator_m"] = m.ego_progress_denominator_m;
+      traj["drivable_area_compliance"] = m.drivable_area_compliance;
+      traj["drivable_area_compliance_available"] = m.drivable_area_compliance_available;
+      traj["drivable_area_compliance_reason"] = m.drivable_area_compliance_reason;
+      traj["no_at_fault_collision"] = m.no_at_fault_collision;
+      traj["no_at_fault_collision_available"] = m.no_at_fault_collision_available;
+      traj["no_at_fault_collision_reason"] = m.no_at_fault_collision_reason;
+      traj["time_to_at_fault_collision_s"] = m.time_to_at_fault_collision_s;
+      traj["driving_direction_compliance"] = m.driving_direction_compliance;
+      traj["driving_direction_compliance_available"] = m.driving_direction_compliance_available;
+      traj["driving_direction_compliance_reason"] = m.driving_direction_compliance_reason;
+      traj["max_oncoming_progress_m"] = m.max_oncoming_progress_m;
+      traj["traffic_light_compliance"] = m.traffic_light_compliance;
+      traj["traffic_light_compliance_available"] = m.traffic_light_compliance_available;
+      traj["traffic_light_compliance_reason"] = m.traffic_light_compliance_reason;
+      if (i < human_filter_metrics_list_.size()) {
+        const auto & hf = human_filter_metrics_list_[i];
+        traj["human_reference"]["history_comfort"] = hf.history_comfort.human_reference;
+        traj["human_reference"]["history_comfort_available"] =
+          hf.history_comfort.human_reference_available;
+        traj["human_reference"]["ego_progress"] = hf.ego_progress.human_reference;
+        traj["human_reference"]["ego_progress_available"] =
+          hf.ego_progress.human_reference_available;
+        traj["human_reference"]["time_to_collision_within_bound"] =
+          hf.time_to_collision_within_bound.human_reference;
+        traj["human_reference"]["time_to_collision_within_bound_available"] =
+          hf.time_to_collision_within_bound.human_reference_available;
+        traj["human_reference"]["lane_keeping"] = hf.lane_keeping.human_reference;
+        traj["human_reference"]["lane_keeping_available"] =
+          hf.lane_keeping.human_reference_available;
+        traj["human_reference"]["drivable_area_compliance"] =
+          hf.drivable_area_compliance.human_reference;
+        traj["human_reference"]["drivable_area_compliance_available"] =
+          hf.drivable_area_compliance.human_reference_available;
+        traj["human_reference"]["no_at_fault_collision"] = hf.no_at_fault_collision.human_reference;
+        traj["human_reference"]["no_at_fault_collision_available"] =
+          hf.no_at_fault_collision.human_reference_available;
+        traj["human_reference"]["driving_direction_compliance"] =
+          hf.driving_direction_compliance.human_reference;
+        traj["human_reference"]["driving_direction_compliance_available"] =
+          hf.driving_direction_compliance.human_reference_available;
+        traj["human_reference"]["traffic_light_compliance"] =
+          hf.traffic_light_compliance.human_reference;
+        traj["human_reference"]["traffic_light_compliance_available"] =
+          hf.traffic_light_compliance.human_reference_available;
 
-      traj["human_filtered"]["history_comfort"] = hf.history_comfort.filtered;
-      traj["human_filtered"]["history_comfort_filter_applied"] = hf.history_comfort.filter_applied;
-      traj["human_filtered"]["ego_progress"] = hf.ego_progress.filtered;
-      traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress.filter_applied;
-      traj["human_filtered"]["time_to_collision_within_bound"] =
-        hf.time_to_collision_within_bound.filtered;
-      traj["human_filtered"]["time_to_collision_within_bound_filter_applied"] =
-        hf.time_to_collision_within_bound.filter_applied;
-      traj["human_filtered"]["lane_keeping"] = hf.lane_keeping.filtered;
-      traj["human_filtered"]["lane_keeping_filter_applied"] = hf.lane_keeping.filter_applied;
-      traj["human_filtered"]["drivable_area_compliance"] = hf.drivable_area_compliance.filtered;
-      traj["human_filtered"]["drivable_area_compliance_filter_applied"] =
-        hf.drivable_area_compliance.filter_applied;
-      traj["human_filtered"]["no_at_fault_collision"] = hf.no_at_fault_collision.filtered;
-      traj["human_filtered"]["no_at_fault_collision_filter_applied"] =
-        hf.no_at_fault_collision.filter_applied;
-      traj["human_filtered"]["driving_direction_compliance"] =
-        hf.driving_direction_compliance.filtered;
-      traj["human_filtered"]["driving_direction_compliance_filter_applied"] =
-        hf.driving_direction_compliance.filter_applied;
-      traj["human_filtered"]["traffic_light_compliance"] = hf.traffic_light_compliance.filtered;
-      traj["human_filtered"]["traffic_light_compliance_filter_applied"] =
-        hf.traffic_light_compliance.filter_applied;
-    }
-    if (i < synthetic_epdms_metrics_list_.size()) {
-      const auto & s = synthetic_epdms_metrics_list_[i];
-      traj["synthetic_epdms"]["raw_available"] = s.raw.available;
-      traj["synthetic_epdms"]["raw_multiplicative_metrics_prod"] =
-        s.raw.multiplicative_metrics_prod;
-      traj["synthetic_epdms"]["raw_weighted_metrics"] = s.raw.weighted_metrics;
-      traj["synthetic_epdms"]["raw"] = s.raw.epdms;
-      traj["synthetic_epdms"]["human_filtered_available"] = s.human_filtered.available;
-      traj["synthetic_epdms"]["human_filtered_multiplicative_metrics_prod"] =
-        s.human_filtered.multiplicative_metrics_prod;
-      traj["synthetic_epdms"]["human_filtered_weighted_metrics"] =
-        s.human_filtered.weighted_metrics;
-      traj["synthetic_epdms"]["human_filtered"] = s.human_filtered.epdms;
+        traj["human_filtered"]["history_comfort"] = hf.history_comfort.filtered;
+        traj["human_filtered"]["history_comfort_filter_applied"] =
+          hf.history_comfort.filter_applied;
+        traj["human_filtered"]["ego_progress"] = hf.ego_progress.filtered;
+        traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress.filter_applied;
+        traj["human_filtered"]["time_to_collision_within_bound"] =
+          hf.time_to_collision_within_bound.filtered;
+        traj["human_filtered"]["time_to_collision_within_bound_filter_applied"] =
+          hf.time_to_collision_within_bound.filter_applied;
+        traj["human_filtered"]["lane_keeping"] = hf.lane_keeping.filtered;
+        traj["human_filtered"]["lane_keeping_filter_applied"] = hf.lane_keeping.filter_applied;
+        traj["human_filtered"]["drivable_area_compliance"] = hf.drivable_area_compliance.filtered;
+        traj["human_filtered"]["drivable_area_compliance_filter_applied"] =
+          hf.drivable_area_compliance.filter_applied;
+        traj["human_filtered"]["no_at_fault_collision"] = hf.no_at_fault_collision.filtered;
+        traj["human_filtered"]["no_at_fault_collision_filter_applied"] =
+          hf.no_at_fault_collision.filter_applied;
+        traj["human_filtered"]["driving_direction_compliance"] =
+          hf.driving_direction_compliance.filtered;
+        traj["human_filtered"]["driving_direction_compliance_filter_applied"] =
+          hf.driving_direction_compliance.filter_applied;
+        traj["human_filtered"]["traffic_light_compliance"] = hf.traffic_light_compliance.filtered;
+        traj["human_filtered"]["traffic_light_compliance_filter_applied"] =
+          hf.traffic_light_compliance.filter_applied;
+      }
+      if (i < synthetic_epdms_metrics_list_.size()) {
+        const auto & s = synthetic_epdms_metrics_list_[i];
+        traj["synthetic_epdms"]["raw_available"] = s.raw.available;
+        traj["synthetic_epdms"]["raw_multiplicative_metrics_prod"] =
+          s.raw.multiplicative_metrics_prod;
+        traj["synthetic_epdms"]["raw_weighted_metrics"] = s.raw.weighted_metrics;
+        traj["synthetic_epdms"]["raw"] = s.raw.epdms;
+        traj["synthetic_epdms"]["human_filtered_available"] = s.human_filtered.available;
+        traj["synthetic_epdms"]["human_filtered_multiplicative_metrics_prod"] =
+          s.human_filtered.multiplicative_metrics_prod;
+        traj["synthetic_epdms"]["human_filtered_weighted_metrics"] =
+          s.human_filtered.weighted_metrics;
+        traj["synthetic_epdms"]["human_filtered"] = s.human_filtered.epdms;
+      }
     }
 
     traj["horizon_results"] = nlohmann::json::object();
     fill_horizon_json(traj["horizon_results"], m.horizon_results, m.num_points);
 
-    if (i < trajectory_point_metrics_list_.size()) {
+    if (enabled_metrics_.enable_epdms_calculation && i < trajectory_point_metrics_list_.size()) {
       const auto & pm = trajectory_point_metrics_list_[i];
       traj["trajectory_point_metrics"]["longitudinal_accelerations"] =
         pm.longitudinal_accelerations;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -380,7 +380,8 @@ void OpenLoopEvaluator::set_enabled_metrics(const std::vector<std::string> & ena
 
 bool OpenLoopEvaluator::should_write_synthetic_epdms() const
 {
-  return enabled_metrics_.synthetic_epdms && all_epdms_inputs_enabled(enabled_metrics_);
+  return enabled_metrics_.synthetic_epdms && enabled_metrics_.enable_epdms_calculation &&
+         all_epdms_inputs_enabled(enabled_metrics_);
 }
 
 void OpenLoopEvaluator::evaluate(
@@ -468,69 +469,76 @@ void OpenLoopEvaluator::evaluate(
 
       try {
         const auto & eval_data = evaluation_data_list[i];
-        const auto future_objects =
-          eval_data.synchronized_data && eval_data.synchronized_data->trajectory
-            ? metrics::get_future_objects_for_trajectory(
-                *eval_data.synchronized_data->trajectory, object_timeline_,
-                trajectory_evaluation_horizon_s_)
-            : std::vector<TimedTrackedObjects>{};
-        const metrics::TrajectoryMetricDebugEnabledMetrics debug_enabled_metrics{
-          debug_topics_enabled_ && enabled_metrics_.time_to_collision_within_bound,
-          debug_topics_enabled_ && enabled_metrics_.no_at_fault_collision,
-          debug_topics_enabled_ && enabled_metrics_.drivable_area_compliance,
-          debug_topics_enabled_ && enabled_metrics_.lane_keeping,
-          debug_topics_enabled_ && enabled_metrics_.driving_direction_compliance,
-          debug_topics_enabled_ && enabled_metrics_.traffic_light_compliance};
-        auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
-          eval_data.synchronized_data, route_handler_, history_comfort_params_,
-          lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects,
-          debug_enabled_metrics);
-        auto metrics = evaluate_trajectory(eval_data);
-        metrics.history_comfort = trajectory_metrics.history_comfort;
-        metrics.history_comfort_available = trajectory_metrics.history_comfort_available;
-        metrics.history_comfort_reason = trajectory_metrics.history_comfort_reason;
-        metrics.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
-        metrics.time_to_collision_within_bound_available =
-          trajectory_metrics.time_to_collision_within_bound_available;
-        metrics.time_to_collision_within_bound_reason =
-          trajectory_metrics.time_to_collision_within_bound_reason;
-        metrics.time_to_collision_infraction_time_s =
-          trajectory_metrics.time_to_collision_infraction_time_s;
-        metrics.lane_keeping = trajectory_metrics.lane_keeping;
-        metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
-        metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
-        metrics.ego_progress = trajectory_metrics.ego_progress;
-        metrics.ego_progress_available = trajectory_metrics.ego_progress_available;
-        metrics.ego_progress_reason = trajectory_metrics.ego_progress_reason;
-        metrics.ego_progress_raw_m = trajectory_metrics.ego_progress_raw_m;
-        metrics.ego_progress_best_raw_m = trajectory_metrics.ego_progress_best_raw_m;
-        metrics.ego_progress_mask = trajectory_metrics.ego_progress_mask;
-        metrics.ego_progress_denominator_m = trajectory_metrics.ego_progress_denominator_m;
-        metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
-        metrics.drivable_area_compliance_available =
-          trajectory_metrics.drivable_area_compliance_available;
-        metrics.drivable_area_compliance_reason =
-          trajectory_metrics.drivable_area_compliance_reason;
-        metrics.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
-        metrics.no_at_fault_collision_available =
-          trajectory_metrics.no_at_fault_collision_available;
-        metrics.no_at_fault_collision_reason = trajectory_metrics.no_at_fault_collision_reason;
-        metrics.time_to_at_fault_collision_s = trajectory_metrics.time_to_at_fault_collision_s;
-        metrics.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
-        metrics.driving_direction_compliance_available =
-          trajectory_metrics.driving_direction_compliance_available;
-        metrics.driving_direction_compliance_reason =
-          trajectory_metrics.driving_direction_compliance_reason;
-        metrics.max_oncoming_progress_m = trajectory_metrics.max_oncoming_progress_m;
-        metrics.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
-        metrics.traffic_light_compliance_available =
-          trajectory_metrics.traffic_light_compliance_available;
-        metrics.traffic_light_compliance_reason =
-          trajectory_metrics.traffic_light_compliance_reason;
+        metrics::TrajectoryPointMetrics trajectory_metrics;
+        metrics::EpdmsMetricSnapshot human_snapshot;
+        if (enabled_metrics_.enable_epdms_calculation) {
+          const auto future_objects =
+            eval_data.synchronized_data && eval_data.synchronized_data->trajectory
+              ? metrics::get_future_objects_for_trajectory(
+                  *eval_data.synchronized_data->trajectory, object_timeline_,
+                  trajectory_evaluation_horizon_s_)
+              : std::vector<TimedTrackedObjects>{};
+          const metrics::TrajectoryMetricDebugEnabledMetrics debug_enabled_metrics{
+            debug_topics_enabled_ && enabled_metrics_.time_to_collision_within_bound,
+            debug_topics_enabled_ && enabled_metrics_.no_at_fault_collision,
+            debug_topics_enabled_ && enabled_metrics_.drivable_area_compliance,
+            debug_topics_enabled_ && enabled_metrics_.lane_keeping,
+            debug_topics_enabled_ && enabled_metrics_.driving_direction_compliance,
+            debug_topics_enabled_ && enabled_metrics_.traffic_light_compliance};
+          trajectory_metrics = metrics::calculate_trajectory_point_metrics(
+            eval_data.synchronized_data, route_handler_, history_comfort_params_,
+            lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects,
+            debug_enabled_metrics);
+          human_snapshot = calculate_human_reference_snapshot(
+            eval_data, route_handler_, history_comfort_params_, lane_keeping_params_,
+            driving_direction_params_, vehicle_info_);
+        }
 
-        auto human_snapshot = calculate_human_reference_snapshot(
-          eval_data, route_handler_, history_comfort_params_, lane_keeping_params_,
-          driving_direction_params_, vehicle_info_);
+        auto metrics = evaluate_trajectory(eval_data);
+        if (enabled_metrics_.enable_epdms_calculation) {
+          metrics.history_comfort = trajectory_metrics.history_comfort;
+          metrics.history_comfort_available = trajectory_metrics.history_comfort_available;
+          metrics.history_comfort_reason = trajectory_metrics.history_comfort_reason;
+          metrics.time_to_collision_within_bound =
+            trajectory_metrics.time_to_collision_within_bound;
+          metrics.time_to_collision_within_bound_available =
+            trajectory_metrics.time_to_collision_within_bound_available;
+          metrics.time_to_collision_within_bound_reason =
+            trajectory_metrics.time_to_collision_within_bound_reason;
+          metrics.time_to_collision_infraction_time_s =
+            trajectory_metrics.time_to_collision_infraction_time_s;
+          metrics.lane_keeping = trajectory_metrics.lane_keeping;
+          metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
+          metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
+          metrics.ego_progress = trajectory_metrics.ego_progress;
+          metrics.ego_progress_available = trajectory_metrics.ego_progress_available;
+          metrics.ego_progress_reason = trajectory_metrics.ego_progress_reason;
+          metrics.ego_progress_raw_m = trajectory_metrics.ego_progress_raw_m;
+          metrics.ego_progress_best_raw_m = trajectory_metrics.ego_progress_best_raw_m;
+          metrics.ego_progress_mask = trajectory_metrics.ego_progress_mask;
+          metrics.ego_progress_denominator_m = trajectory_metrics.ego_progress_denominator_m;
+          metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
+          metrics.drivable_area_compliance_available =
+            trajectory_metrics.drivable_area_compliance_available;
+          metrics.drivable_area_compliance_reason =
+            trajectory_metrics.drivable_area_compliance_reason;
+          metrics.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
+          metrics.no_at_fault_collision_available =
+            trajectory_metrics.no_at_fault_collision_available;
+          metrics.no_at_fault_collision_reason = trajectory_metrics.no_at_fault_collision_reason;
+          metrics.time_to_at_fault_collision_s = trajectory_metrics.time_to_at_fault_collision_s;
+          metrics.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
+          metrics.driving_direction_compliance_available =
+            trajectory_metrics.driving_direction_compliance_available;
+          metrics.driving_direction_compliance_reason =
+            trajectory_metrics.driving_direction_compliance_reason;
+          metrics.max_oncoming_progress_m = trajectory_metrics.max_oncoming_progress_m;
+          metrics.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
+          metrics.traffic_light_compliance_available =
+            trajectory_metrics.traffic_light_compliance_available;
+          metrics.traffic_light_compliance_reason =
+            trajectory_metrics.traffic_light_compliance_reason;
+        }
 
         metrics_list_[i] = std::move(metrics);
         trajectory_point_metrics_list_[i] = std::move(trajectory_metrics);
@@ -591,6 +599,14 @@ void OpenLoopEvaluator::evaluate(
         auto & metrics = metrics_list_[i];
         auto & human_snapshot = human_snapshots[i];
 
+        if (!enabled_metrics_.enable_epdms_calculation) {
+          const auto processed = phase2_processed.fetch_add(1U) + 1U;
+          if (processed % kProgressLogInterval == 0U || processed == total_samples) {
+            log_parallel_progress("Parallel phase 2", processed, total_samples);
+          }
+          continue;
+        }
+
         if (i == 0U) {
           metrics.extended_comfort = 0.0;
           metrics.extended_comfort_available = false;
@@ -633,8 +649,12 @@ void OpenLoopEvaluator::evaluate(
         const auto agent_snapshot = build_epdms_snapshot(metrics);
         human_filter_metrics_list_[i] =
           metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
-        synthetic_epdms_metrics_list_[i] =
-          metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
+        if (enabled_metrics_.enable_epdms_calculation) {
+          synthetic_epdms_metrics_list_[i] =
+            metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
+        } else {
+          synthetic_epdms_metrics_list_[i] = metrics::SyntheticEpdmsMetrics{};
+        }
 
         const auto processed = phase2_processed.fetch_add(1U) + 1U;
         if (processed % kProgressLogInterval == 0U || processed == total_samples) {
@@ -1288,7 +1308,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   std_msgs::msg::Float64 scalar_msg;
   const auto write_scalar =
     [&](const bool enabled, const double value, const std::string & topic_name) {
-      if (!enabled) {
+      if (!enabled_metrics_.enable_epdms_calculation || !enabled) {
         return;
       }
       scalar_msg.data = value;
@@ -1336,7 +1356,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   std_msgs::msg::Bool availability_msg;
   const auto write_availability =
     [&](const bool enabled, const bool value, const std::string & topic_name) {
-      if (!enabled) {
+      if (!enabled_metrics_.enable_epdms_calculation || !enabled) {
         return;
       }
       availability_msg.data = value;
@@ -1381,7 +1401,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   std_msgs::msg::String reason_msg;
   const auto write_reason =
     [&](const bool enabled, const std::string & value, const std::string & topic_name) {
-      if (!enabled) {
+      if (!enabled_metrics_.enable_epdms_calculation || !enabled) {
         return;
       }
       reason_msg.data = value;
@@ -1426,7 +1446,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
     bag_writer.write(gt_traj_msg, compared_trajectory_topic(), message_timestamp);
   }
 
-  if (debug_topics_enabled_) {
+  if (enabled_metrics_.enable_epdms_calculation && debug_topics_enabled_) {
     metrics::write_epdms_trajectory_horizon_debug_topics_to_bag(
       *trajectory_data->trajectory, ground_truth_trajectory, vehicle_info_, bag_writer,
       message_timestamp);
@@ -1444,6 +1464,10 @@ void OpenLoopEvaluator::save_trajectory_point_metrics_to_bag_with_variant(
   const metrics::TrajectoryPointMetrics & metrics, rosbag2_cpp::Writer & bag_writer,
   const rclcpp::Time & normalized_timestamp) const
 {
+  if (!enabled_metrics_.enable_epdms_calculation) {
+    return;
+  }
+
   const auto write_array =
     [&](const bool enabled, const std::vector<double> & data, const std::string & topic_name) {
       if (!enabled) {
@@ -2306,14 +2330,17 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     };
   const auto add_epdms_topic_if =
     [&](const bool enabled, const std::string & name, const std::string & type) {
-      add_topic_if(enabled, epdms_metric_topic(name), type);
+      add_topic_if(
+        enabled_metrics_.enable_epdms_calculation && enabled, epdms_metric_topic(name), type);
     };
   const auto add_epdms_availability_reason_if = [&](const bool enabled, const std::string & name) {
     add_epdms_topic_if(enabled, name + "_available", "std_msgs/msg/Bool");
     add_epdms_topic_if(enabled, name + "_reason", "std_msgs/msg/String");
   };
   const auto add_trajectory_array_if = [&](const bool enabled, const std::string & name) {
-    add_topic_if(enabled, trajectory_metric_topic(name), "std_msgs/msg/Float64MultiArray");
+    add_topic_if(
+      enabled_metrics_.enable_epdms_calculation && enabled, trajectory_metric_topic(name),
+      "std_msgs/msg/Float64MultiArray");
   };
 
   add_topic(dlr_result_topic(), "std_msgs/msg/String");
@@ -2329,9 +2356,7 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
   if (enabled_metrics_.time_to_collision_within_bound) {
     add_topic(metric_topic("ttc"), "std_msgs/msg/Float64MultiArray");
   }
-  if (enabled_metrics_.history_comfort) {
-    add_topic(epdms_metric_topic("history_comfort"), "std_msgs/msg/Float64");
-  }
+  add_epdms_topic_if(enabled_metrics_.history_comfort, "history_comfort", "std_msgs/msg/Float64");
   add_epdms_availability_reason_if(enabled_metrics_.history_comfort, "history_comfort");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "longitudinal_accelerations");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "lateral_accelerations");
@@ -2390,7 +2415,7 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     "/perception/object_recognition/objects", "autoware_perception_msgs/msg/PredictedObjects");
   add_topic("/tf", "tf2_msgs/msg/TFMessage");
   add_topic("/tf_static", "tf2_msgs/msg/TFMessage");
-  if (debug_topics_enabled_) {
+  if (enabled_metrics_.enable_epdms_calculation && debug_topics_enabled_) {
     metrics::add_epdms_debug_result_topics(
       topics, make_epdms_debug_enabled_metrics(enabled_metrics_));
   }

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -79,6 +79,12 @@ struct OpenLoopTrajectoryMetrics
   double extended_comfort{0.0};  // Binary extended comfort subscore
   bool extended_comfort_available{false};
   std::string extended_comfort_reason{"unavailable"};
+  std::string extended_comfort_debug_summary;
+  std::vector<double> extended_comfort_sample_times;
+  std::vector<double> extended_comfort_delta_acceleration;
+  std::vector<double> extended_comfort_delta_jerk;
+  std::vector<double> extended_comfort_delta_yaw_rate;
+  std::vector<double> extended_comfort_delta_yaw_accel;
   double time_to_collision_within_bound{0.0};
   bool time_to_collision_within_bound_available{false};
   std::string time_to_collision_within_bound_reason{"unavailable"};

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -166,6 +166,7 @@ struct EnabledOpenLoopMetrics
   bool driving_direction_compliance{true};
   bool traffic_light_compliance{true};
   bool synthetic_epdms{true};
+  bool enable_epdms_calculation{true};
 };
 
 class OpenLoopEvaluator : public BaseEvaluator
@@ -210,6 +211,11 @@ public:
   void set_metric_variant(const std::string & metric_variant) { metric_variant_ = metric_variant; }
 
   void set_enabled_metrics(const std::vector<std::string> & enabled_metric_names);
+
+  void set_epdms_calculation_enabled(bool enabled)
+  {
+    enabled_metrics_.enable_epdms_calculation = enabled;
+  }
 
   void set_debug_topics_enabled(bool enabled) { debug_topics_enabled_ = enabled; }
 

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
@@ -233,7 +233,7 @@ TEST(DrivableAreaComplianceTest, ReturnsZeroWhenAnyCornerLeavesDrivableArea)
 {
   const auto result = calculate_drivable_area_compliance(
     make_trajectory(1.5), make_route_handler({make_road_lanelet(1, -2.0, 2.0)}),
-    make_vehicle_info());
+    make_vehicle_info(), nullptr, true);
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_lane_keeping.cpp
@@ -31,8 +31,14 @@ LaneKeepingEvaluationPoint make_evaluation_point(
   const double speed_mps = 5.0, const double cumulative_progress_m = 0.0)
 {
   return LaneKeepingEvaluationPoint{
-    rclcpp::Duration::from_seconds(seconds), lateral_deviation, is_in_intersection, speed_mps,
-    cumulative_progress_m};
+    rclcpp::Duration::from_seconds(seconds),
+    lateral_deviation,
+    is_in_intersection,
+    speed_mps,
+    cumulative_progress_m,
+    geometry_msgs::msg::Point{},
+    {},
+    -1};
 }
 
 LaneKeepingParameters make_parameters()

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -236,6 +236,35 @@ TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)
   EXPECT_TRUE(has_topic("/open_loop/metrics/epdms/synthetic_epdms_human_filtered_available"));
 }
 
+TEST_F(OpenLoopGTSourceModeTest, EpdmsGateDisablesEpdmsResultTopics)
+{
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+
+  evaluator.set_debug_topics_enabled(true);
+  evaluator.set_epdms_calculation_enabled(false);
+
+  const auto topics = evaluator.get_result_topics();
+  const auto has_topic = [&topics](const std::string & topic_name) {
+    return std::any_of(topics.begin(), topics.end(), [&topic_name](const auto & topic) {
+      return topic.first == topic_name;
+    });
+  };
+  const auto has_topic_prefix = [&topics](const std::string & prefix) {
+    return std::any_of(topics.begin(), topics.end(), [&prefix](const auto & topic) {
+      return topic.first.rfind(prefix, 0) == 0;
+    });
+  };
+
+  EXPECT_TRUE(has_topic("/open_loop/metrics/ade"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/fde"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/ttc"));
+  EXPECT_FALSE(has_topic_prefix("/open_loop/metrics/epdms/"));
+  EXPECT_FALSE(has_topic_prefix("/open_loop/metrics/trajectory/"));
+  EXPECT_FALSE(has_topic_prefix("/debug/epdms/"));
+}
+
 TEST_F(OpenLoopGTSourceModeTest, EnabledMetricsNarrowsOpenLoopResultTopics)
 {
   OpenLoopEvaluator evaluator(


### PR DESCRIPTION
## Summary
- Backport EPDMS debug topics support.
- Backport enable_epdms_calculation launch/config/node wiring.
- Backport EPDMS JSON output gating and dead-code cleanup.
- Backport debug_topics_enabled launch argument exposure.

## Upstream
- Backports upstream PR: https://github.com/autowarefoundation/autoware_tools/pull/441
  - feat(planning_data_analyzer): add EPDMS debug topics
- Backports upstream PR: https://github.com/autowarefoundation/autoware_tools/pull/458
  - feat(planning_data_analyzer): add EPDMS calculation gate
  - fix(planning_data_analyzer): gate EPDMS JSON output
  - fix(planning_data_analyzer): remove unreachable EPDMS branch
- Backports upstream PR: https://github.com/autowarefoundation/autoware_tools/pull/459
  - feat(planning_data_analyzer): expose EPDMS debug launch gate
- Includes beta-compatible lanelet API preservation for the v0.64 underlay.

## Validation
- Evaluator run: https://evaluation.ci.tier4.jp/evaluation/reports/c2024e7c-c59b-59c7-8aaa-85b4e82ab308?project_id=x2_dev

All EPDMS metrics and debug topics are produced as intended.